### PR TITLE
Update ALPSS results and laser shock parameter schemas

### DIFF
--- a/alpss_results.json
+++ b/alpss_results.json
@@ -17,6 +17,24 @@
             "propertyOrder": 2,
             "title": "Velocity OK"
         },
+        "spall_ok": {
+            "type": [
+                "boolean",
+                "null"
+            ],
+            "default": null,
+            "propertyOrder": 3,
+            "title": "Spall OK"
+        },
+        "uncertainty_ok": {
+            "type": [
+                "boolean",
+                "null"
+            ],
+            "default": null,
+            "propertyOrder": 4,
+            "title": "Uncertainty OK"
+        },
         "Sample_IGSN": {
             "type": [
                 "string",
@@ -34,7 +52,7 @@
                     "debounceTime": 500
                 }
             },
-            "propertyOrder": 3,
+            "propertyOrder": 5,
             "title": "Sample_IGSN"
         },
         "run_time": {
@@ -43,7 +61,7 @@
                 "null"
             ],
             "default": null,
-            "propertyOrder": 4,
+            "propertyOrder": 6,
             "title": "Run Time"
         },
         "velocity_at_max_compression": {
@@ -52,7 +70,7 @@
                 "null"
             ],
             "default": null,
-            "propertyOrder": 5,
+            "propertyOrder": 7,
             "title": "Velocity at Max Compression"
         },
         "time_at_max_compression": {
@@ -61,7 +79,7 @@
                 "null"
             ],
             "default": null,
-            "propertyOrder": 6,
+            "propertyOrder": 8,
             "title": "Time at Max Compression"
         },
         "velocity_at_max_tension": {
@@ -70,7 +88,7 @@
                 "null"
             ],
             "default": null,
-            "propertyOrder": 7,
+            "propertyOrder": 9,
             "title": "Velocity at Max Tension"
         },
         "time_at_max_tension": {
@@ -79,7 +97,7 @@
                 "null"
             ],
             "default": null,
-            "propertyOrder": 8,
+            "propertyOrder": 10,
             "title": "Time at Max Tension"
         },
         "velocity_at_recompression": {
@@ -88,7 +106,7 @@
                 "null"
             ],
             "default": null,
-            "propertyOrder": 9,
+            "propertyOrder": 11,
             "title": "Velocity at Recompression"
         },
         "time_at_recompression": {
@@ -97,7 +115,7 @@
                 "null"
             ],
             "default": null,
-            "propertyOrder": 10,
+            "propertyOrder": 12,
             "title": "Time at Recompression"
         },
         "carrier_frequency": {
@@ -106,7 +124,7 @@
                 "null"
             ],
             "default": null,
-            "propertyOrder": 11,
+            "propertyOrder": 13,
             "title": "Carrier Frequency"
         },
         "spall_strength": {
@@ -115,7 +133,7 @@
                 "null"
             ],
             "default": null,
-            "propertyOrder": 12,
+            "propertyOrder": 14,
             "title": "Spall Strength"
         },
         "spall_strength_uncertainty": {
@@ -124,7 +142,7 @@
                 "null"
             ],
             "default": null,
-            "propertyOrder": 13,
+            "propertyOrder": 15,
             "title": "Spall Strength Uncertainty"
         },
         "strain_rate": {
@@ -133,7 +151,7 @@
                 "null"
             ],
             "default": null,
-            "propertyOrder": 14,
+            "propertyOrder": 16,
             "title": "Strain Rate"
         },
         "strain_rate_uncertainty": {
@@ -142,7 +160,7 @@
                 "null"
             ],
             "default": null,
-            "propertyOrder": 15,
+            "propertyOrder": 17,
             "title": "Strain Rate Uncertainty"
         },
         "peak_shock_stress": {
@@ -151,7 +169,7 @@
                 "null"
             ],
             "default": null,
-            "propertyOrder": 16,
+            "propertyOrder": 18,
             "title": "Peak Shock Stress"
         },
         "spect_time_res": {
@@ -160,7 +178,7 @@
                 "null"
             ],
             "default": null,
-            "propertyOrder": 17,
+            "propertyOrder": 19,
             "title": "Spect Time Res"
         },
         "spect_freq_res": {
@@ -169,7 +187,7 @@
                 "null"
             ],
             "default": null,
-            "propertyOrder": 18,
+            "propertyOrder": 20,
             "title": "Spect Freq Res"
         },
         "spect_velocity_res": {
@@ -178,7 +196,7 @@
                 "null"
             ],
             "default": null,
-            "propertyOrder": 19,
+            "propertyOrder": 21,
             "title": "Spect Velocity Res"
         },
         "signal_start_time": {
@@ -187,7 +205,7 @@
                 "null"
             ],
             "default": null,
-            "propertyOrder": 20,
+            "propertyOrder": 22,
             "title": "Signal Start Time"
         },
         "smoothing_characteristic_time": {
@@ -196,12 +214,12 @@
                 "null"
             ],
             "default": null,
-            "propertyOrder": 21,
+            "propertyOrder": 23,
             "title": "Smoothing Characteristic Time"
         },
         "version": {
             "type": "string",
-            "propertyOrder": 22,
+            "propertyOrder": 24,
             "title": "Version"
         },
         "hel_detected": {
@@ -210,7 +228,7 @@
                 "null"
             ],
             "default": null,
-            "propertyOrder": 23,
+            "propertyOrder": 25,
             "title": "HEL Detected"
         },
         "hel_strength_(gpa)": {
@@ -219,7 +237,7 @@
                 "null"
             ],
             "default": null,
-            "propertyOrder": 24,
+            "propertyOrder": 26,
             "title": "HEL Strength (GPa)"
         },
         "hel_uncertainty_(gpa)": {
@@ -228,7 +246,7 @@
                 "null"
             ],
             "default": null,
-            "propertyOrder": 25,
+            "propertyOrder": 27,
             "title": "HEL Uncertainty (GPa)"
         },
         "hel_free_surface_velocity_(m/s)": {
@@ -237,7 +255,7 @@
                 "null"
             ],
             "default": null,
-            "propertyOrder": 26,
+            "propertyOrder": 28,
             "title": "HEL Free Surface Velocity (m/s)"
         },
         "hel_time_detection_(ns)": {
@@ -246,7 +264,7 @@
                 "null"
             ],
             "default": null,
-            "propertyOrder": 27,
+            "propertyOrder": 29,
             "title": "HEL Time Detection (ns)"
         },
         "hel_consecutive_points": {
@@ -255,7 +273,7 @@
                 "null"
             ],
             "default": null,
-            "propertyOrder": 28,
+            "propertyOrder": 30,
             "title": "HEL Consecutive Points"
         },
         "hel_segment_duration_(ns)": {
@@ -264,7 +282,7 @@
                 "null"
             ],
             "default": null,
-            "propertyOrder": 29,
+            "propertyOrder": 31,
             "title": "HEL Segment Duration (ns)"
         },
         "hel_strain_rate": {
@@ -273,12 +291,14 @@
                 "null"
             ],
             "default": null,
-            "propertyOrder": 30,
+            "propertyOrder": 32,
             "title": "HEL Strain Rate"
         }
     },
     "required": [
         "velocity_ok",
+        "spall_ok",
+        "uncertainty_ok",
         "file_name",
         "run_time",
         "velocity_at_max_compression",

--- a/alpss_results.json
+++ b/alpss_results.json
@@ -3,9 +3,8 @@
     "title": "ALPSS Result Schema",
     "type": "object",
     "properties": {
-        "file_name": {
+        "File Name": {
             "type": "string",
-            "title": "File Name",
             "propertyOrder": 1
         },
         "Sample_IGSN": {
@@ -13,7 +12,6 @@
                 "string",
                 "null"
             ],
-            "title": "Sample_IGSN",
             "description": "Lookup for the IGSN of the sample",
             "format": "autocomplete",
             "options": {
@@ -27,122 +25,103 @@
             },
             "propertyOrder": 2
         },
-        "run_time": {
+        "Run Time": {
             "type": "number",
-            "title": "Run Time",
             "propertyOrder": 3
         },
-        "velocity_at_max_compression": {
+        "Velocity at Max Compression": {
             "type": "number",
-            "title": "Velocity at Max Compression",
             "propertyOrder": 4
         },
-        "time_at_max_compression": {
+        "Time at Max Compression": {
             "type": "number",
-            "title": "Time at Max Compression",
             "propertyOrder": 5
         },
-        "velocity_at_max_tension": {
+        "Velocity at Max Tension": {
             "type": "number",
-            "title": "Velocity at Max Tension",
             "propertyOrder": 6
         },
-        "time_at_max_tension": {
+        "Time at Max Tension": {
             "type": "number",
-            "title": "Time at Max Tension",
             "propertyOrder": 7
         },
-        "velocity_at_recompression": {
+        "Velocity at Recompression": {
             "type": "number",
-            "title": "Velocity at Recompression",
             "propertyOrder": 8
         },
-        "time_at_recompression": {
+        "Time at Recompression": {
             "type": "number",
-            "title": "Time at Recompression",
             "propertyOrder": 9
         },
-        "carrier_frequency": {
+        "Carrier Frequency": {
             "type": "number",
-            "title": "Carrier Frequency",
             "propertyOrder": 10
         },
-        "spall_strength": {
+        "Spall Strength": {
             "type": "number",
-            "title": "Spall Strength",
             "propertyOrder": 11
         },
-        "spall_strength_uncertainty": {
+        "Spall Strength Uncertainty": {
             "type": "number",
-            "title": "Spall Strength Uncertainty",
             "propertyOrder": 12
         },
-        "strain_rate": {
+        "Strain Rate": {
             "type": "number",
-            "title": "Strain Rate",
             "propertyOrder": 13
         },
-        "strain_rate_uncertainty": {
+        "Strain Rate Uncertainty": {
             "type": "number",
-            "title": "Strain Rate Uncertainty",
             "propertyOrder": 14
         },
-        "peak_shock_stress": {
+        "Peak Shock Stress": {
             "type": "number",
-            "title": "Peak Shock Stress",
             "propertyOrder": 15
         },
-        "spect_time_res": {
+        "Spect Time Res": {
             "type": "number",
-            "title": "Spect Time Res",
             "propertyOrder": 16
         },
-        "spect_freq_res": {
+        "Spect Freq Res": {
             "type": "number",
-            "title": "Spect Freq Res",
             "propertyOrder": 17
         },
-        "spect_velocity_res": {
+        "Spect Velocity Res": {
             "type": "number",
-            "title": "Spect Velocity Res",
             "propertyOrder": 18
         },
-        "signal_start_time": {
+        "Signal Start Time": {
             "type": "number",
-            "title": "Signal Start Time",
             "propertyOrder": 19
         },
-        "smoothing_characteristic_time": {
+        "Smoothing Characteristic Time": {
             "type": "number",
-            "title": "Smoothing Characteristic Time",
             "propertyOrder": 20
         },
-        "version": {
+        "Version": {
             "type": "string",
-            "title": "Version",
             "propertyOrder": 21
         }
     },
     "required": [
-        "file_name",
-        "run_time",
-        "velocity_at_max_compression",
-        "time_at_max_compression",
-        "velocity_at_max_tension",
-        "time_at_max_tension",
-        "velocity_at_recompression",
-        "time_at_recompression",
-        "carrier_frequency",
-        "spall_strength",
-        "spall_strength_uncertainty",
-        "strain_rate",
-        "strain_rate_uncertainty",
-        "peak_shock_stress",
-        "spect_time_res",
-        "spect_freq_res",
-        "spect_velocity_res",
-        "signal_start_time",
-        "smoothing_characteristic_time",
-        "version"
+        "File Name",
+        "Run Time",
+        "Velocity at Max Compression",
+        "Time at Max Compression",
+        "Velocity at Max Tension",
+        "Time at Max Tension",
+        "Velocity at Recompression",
+        "Time at Recompression",
+        "Carrier Frequency",
+        "Spall Strength",
+        "Spall Strength Uncertainty",
+        "Strain Rate",
+        "Strain Rate Uncertainty",
+        "Peak Shock Stress",
+        "Spect Time Res",
+        "Spect Freq Res",
+        "Spect Velocity Res",
+        "Signal Start Time",
+        "Smoothing Characteristic Time",
+        "Version"
     ]
 }

--- a/alpss_results.json
+++ b/alpss_results.json
@@ -3,9 +3,10 @@
     "title": "ALPSS Result Schema",
     "type": "object",
     "properties": {
-        "File Name": {
+        "file_name": {
             "type": "string",
-            "propertyOrder": 1
+            "propertyOrder": 1,
+            "title": "File Name"
         },
         "Sample_IGSN": {
             "type": [
@@ -23,105 +24,125 @@
                     "debounceTime": 500
                 }
             },
-            "propertyOrder": 2
+            "propertyOrder": 2,
+            "title": "Sample_IGSN"
         },
-        "Run Time": {
+        "run_time": {
             "type": "number",
-            "propertyOrder": 3
+            "propertyOrder": 3,
+            "title": "Run Time"
         },
-        "Velocity at Max Compression": {
+        "velocity_at_max_compression": {
             "type": "number",
-            "propertyOrder": 4
+            "propertyOrder": 4,
+            "title": "Velocity at Max Compression"
         },
-        "Time at Max Compression": {
+        "time_at_max_compression": {
             "type": "number",
-            "propertyOrder": 5
+            "propertyOrder": 5,
+            "title": "Time at Max Compression"
         },
-        "Velocity at Max Tension": {
+        "velocity_at_max_tension": {
             "type": "number",
-            "propertyOrder": 6
+            "propertyOrder": 6,
+            "title": "Velocity at Max Tension"
         },
-        "Time at Max Tension": {
+        "time_at_max_tension": {
             "type": "number",
-            "propertyOrder": 7
+            "propertyOrder": 7,
+            "title": "Time at Max Tension"
         },
-        "Velocity at Recompression": {
+        "velocity_at_recompression": {
             "type": "number",
-            "propertyOrder": 8
+            "propertyOrder": 8,
+            "title": "Velocity at Recompression"
         },
-        "Time at Recompression": {
+        "time_at_recompression": {
             "type": "number",
-            "propertyOrder": 9
+            "propertyOrder": 9,
+            "title": "Time at Recompression"
         },
-        "Carrier Frequency": {
+        "carrier_frequency": {
             "type": "number",
-            "propertyOrder": 10
+            "propertyOrder": 10,
+            "title": "Carrier Frequency"
         },
-        "Spall Strength": {
+        "spall_strength": {
             "type": "number",
-            "propertyOrder": 11
+            "propertyOrder": 11,
+            "title": "Spall Strength"
         },
-        "Spall Strength Uncertainty": {
+        "spall_strength_uncertainty": {
             "type": "number",
-            "propertyOrder": 12
+            "propertyOrder": 12,
+            "title": "Spall Strength Uncertainty"
         },
-        "Strain Rate": {
+        "strain_rate": {
             "type": "number",
-            "propertyOrder": 13
+            "propertyOrder": 13,
+            "title": "Strain Rate"
         },
-        "Strain Rate Uncertainty": {
+        "strain_rate_uncertainty": {
             "type": "number",
-            "propertyOrder": 14
+            "propertyOrder": 14,
+            "title": "Strain Rate Uncertainty"
         },
-        "Peak Shock Stress": {
+        "peak_shock_stress": {
             "type": "number",
-            "propertyOrder": 15
+            "propertyOrder": 15,
+            "title": "Peak Shock Stress"
         },
-        "Spect Time Res": {
+        "spect_time_res": {
             "type": "number",
-            "propertyOrder": 16
+            "propertyOrder": 16,
+            "title": "Spect Time Res"
         },
-        "Spect Freq Res": {
+        "spect_freq_res": {
             "type": "number",
-            "propertyOrder": 17
+            "propertyOrder": 17,
+            "title": "Spect Freq Res"
         },
-        "Spect Velocity Res": {
+        "spect_velocity_res": {
             "type": "number",
-            "propertyOrder": 18
+            "propertyOrder": 18,
+            "title": "Spect Velocity Res"
         },
-        "Signal Start Time": {
+        "signal_start_time": {
             "type": "number",
-            "propertyOrder": 19
+            "propertyOrder": 19,
+            "title": "Signal Start Time"
         },
-        "Smoothing Characteristic Time": {
+        "smoothing_characteristic_time": {
             "type": "number",
-            "propertyOrder": 20
+            "propertyOrder": 20,
+            "title": "Smoothing Characteristic Time"
         },
-        "Version": {
+        "version": {
             "type": "string",
-            "propertyOrder": 21
+            "propertyOrder": 21,
+            "title": "Version"
         }
     },
     "required": [
-        "File Name",
-        "Run Time",
-        "Velocity at Max Compression",
-        "Time at Max Compression",
-        "Velocity at Max Tension",
-        "Time at Max Tension",
-        "Velocity at Recompression",
-        "Time at Recompression",
-        "Carrier Frequency",
-        "Spall Strength",
-        "Spall Strength Uncertainty",
-        "Strain Rate",
-        "Strain Rate Uncertainty",
-        "Peak Shock Stress",
-        "Spect Time Res",
-        "Spect Freq Res",
-        "Spect Velocity Res",
-        "Signal Start Time",
-        "Smoothing Characteristic Time",
-        "Version"
+        "file_name",
+        "run_time",
+        "velocity_at_max_compression",
+        "time_at_max_compression",
+        "velocity_at_max_tension",
+        "time_at_max_tension",
+        "velocity_at_recompression",
+        "time_at_recompression",
+        "carrier_frequency",
+        "spall_strength",
+        "spall_strength_uncertainty",
+        "strain_rate",
+        "strain_rate_uncertainty",
+        "peak_shock_stress",
+        "spect_time_res",
+        "spect_freq_res",
+        "spect_velocity_res",
+        "signal_start_time",
+        "smoothing_characteristic_time",
+        "version"
     ]
 }

--- a/alpss_results.json
+++ b/alpss_results.json
@@ -126,6 +126,11 @@
             "type": "number",
             "title": "Smoothing Characteristic Time",
             "propertyOrder": 22
+        },
+        "version": {
+            "type": "string",
+            "title": "Version",
+            "propertyOrder": 23
         }
     },
     "required": [
@@ -147,6 +152,7 @@
         "spect_freq_res",
         "spect_velocity_res",
         "signal_start_time",
-        "smoothing_characteristic_time"
+        "smoothing_characteristic_time",
+        "version"
     ]
 }

--- a/alpss_results.json
+++ b/alpss_results.json
@@ -35,7 +35,7 @@
             "propertyOrder": 4,
             "title": "Uncertainty OK"
         },
-        "error_msg": {
+        "error_message": {
             "type": [
                 "string",
                 "null"

--- a/alpss_results.json
+++ b/alpss_results.json
@@ -175,6 +175,70 @@
             "type": "string",
             "propertyOrder": 21,
             "title": "Version"
+        },
+        "hel_detected": {
+            "type": [
+                "boolean",
+                "null"
+            ],
+            "propertyOrder": 22,
+            "title": "HEL Detected"
+        },
+        "hel_strength_(gpa)": {
+            "type": [
+                "number",
+                "null"
+            ],
+            "propertyOrder": 23,
+            "title": "HEL Strength (GPa)"
+        },
+        "hel_uncertainty_(gpa)": {
+            "type": [
+                "number",
+                "null"
+            ],
+            "propertyOrder": 24,
+            "title": "HEL Uncertainty (GPa)"
+        },
+        "hel_free_surface_velocity_(m/s)": {
+            "type": [
+                "number",
+                "null"
+            ],
+            "propertyOrder": 25,
+            "title": "HEL Free Surface Velocity (m/s)"
+        },
+        "hel_time_detection_(ns)": {
+            "type": [
+                "number",
+                "null"
+            ],
+            "propertyOrder": 26,
+            "title": "HEL Time Detection (ns)"
+        },
+        "hel_consecutive_points": {
+            "type": [
+                "number",
+                "null"
+            ],
+            "propertyOrder": 27,
+            "title": "HEL Consecutive Points"
+        },
+        "hel_segment_duration_(ns)": {
+            "type": [
+                "number",
+                "null"
+            ],
+            "propertyOrder": 28,
+            "title": "HEL Segment Duration (ns)"
+        },
+        "hel_strain_rate": {
+            "type": [
+                "number",
+                "null"
+            ],
+            "propertyOrder": 29,
+            "title": "HEL Strain Rate"
         }
     },
     "required": [

--- a/alpss_results.json
+++ b/alpss_results.json
@@ -28,92 +28,146 @@
             "title": "Sample_IGSN"
         },
         "run_time": {
-            "type": "number",
+            "type": [
+                "number",
+                "null"
+            ],
             "propertyOrder": 3,
             "title": "Run Time"
         },
         "velocity_at_max_compression": {
-            "type": "number",
+            "type": [
+                "number",
+                "null"
+            ],
             "propertyOrder": 4,
             "title": "Velocity at Max Compression"
         },
         "time_at_max_compression": {
-            "type": "number",
+            "type": [
+                "number",
+                "null"
+            ],
             "propertyOrder": 5,
             "title": "Time at Max Compression"
         },
         "velocity_at_max_tension": {
-            "type": "number",
+            "type": [
+                "number",
+                "null"
+            ],
             "propertyOrder": 6,
             "title": "Velocity at Max Tension"
         },
         "time_at_max_tension": {
-            "type": "number",
+            "type": [
+                "number",
+                "null"
+            ],
             "propertyOrder": 7,
             "title": "Time at Max Tension"
         },
         "velocity_at_recompression": {
-            "type": "number",
+            "type": [
+                "number",
+                "null"
+            ],
             "propertyOrder": 8,
             "title": "Velocity at Recompression"
         },
         "time_at_recompression": {
-            "type": "number",
+            "type": [
+                "number",
+                "null"
+            ],
             "propertyOrder": 9,
             "title": "Time at Recompression"
         },
         "carrier_frequency": {
-            "type": "number",
+            "type": [
+                "number",
+                "null"
+            ],
             "propertyOrder": 10,
             "title": "Carrier Frequency"
         },
         "spall_strength": {
-            "type": "number",
+            "type": [
+                "number",
+                "null"
+            ],
             "propertyOrder": 11,
             "title": "Spall Strength"
         },
         "spall_strength_uncertainty": {
-            "type": "number",
+            "type": [
+                "number",
+                "null"
+            ],
             "propertyOrder": 12,
             "title": "Spall Strength Uncertainty"
         },
         "strain_rate": {
-            "type": "number",
+            "type": [
+                "number",
+                "null"
+            ],
             "propertyOrder": 13,
             "title": "Strain Rate"
         },
         "strain_rate_uncertainty": {
-            "type": "number",
+            "type": [
+                "number",
+                "null"
+            ],
             "propertyOrder": 14,
             "title": "Strain Rate Uncertainty"
         },
         "peak_shock_stress": {
-            "type": "number",
+            "type": [
+                "number",
+                "null"
+            ],
             "propertyOrder": 15,
             "title": "Peak Shock Stress"
         },
         "spect_time_res": {
-            "type": "number",
+            "type": [
+                "number",
+                "null"
+            ],
             "propertyOrder": 16,
             "title": "Spect Time Res"
         },
         "spect_freq_res": {
-            "type": "number",
+            "type": [
+                "number",
+                "null"
+            ],
             "propertyOrder": 17,
             "title": "Spect Freq Res"
         },
         "spect_velocity_res": {
-            "type": "number",
+            "type": [
+                "number",
+                "null"
+            ],
             "propertyOrder": 18,
             "title": "Spect Velocity Res"
         },
         "signal_start_time": {
-            "type": "number",
+            "type": [
+                "number",
+                "null"
+            ],
             "propertyOrder": 19,
             "title": "Signal Start Time"
         },
         "smoothing_characteristic_time": {
-            "type": "number",
+            "type": [
+                "number",
+                "null"
+            ],
             "propertyOrder": 20,
             "title": "Smoothing Characteristic Time"
         },

--- a/alpss_results.json
+++ b/alpss_results.json
@@ -1,91 +1,152 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "title": "PDV Result Schema",
+    "title": "ALPSS Result Schema",
     "type": "object",
     "properties": {
-        "Date": {
-            "type": "string"
+        "date": {
+            "type": "string",
+            "title": "Date",
+            "propertyOrder": 1
         },
-        "Time": {
-            "type": "string"
+        "time": {
+            "type": "string",
+            "title": "Time",
+            "propertyOrder": 2
         },
-        "File Name": {
-            "type": "string"
+        "file_name": {
+            "type": "string",
+            "title": "File Name",
+            "propertyOrder": 3
         },
-        "Run Time": {
-            "type": "number"
+        "Sample_IGSN": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "title": "Sample_IGSN",
+            "description": "Lookup for the IGSN of the sample",
+            "format": "autocomplete",
+            "options": {
+                "autocomplete": {
+                    "search": "search_deposition",
+                    "renderResult": "render_deposition",
+                    "getResultValue": "get_deposition_value",
+                    "autoSelect": true,
+                    "debounceTime": 500
+                }
+            },
+            "propertyOrder": 4
         },
-        "Velocity at Max Compression": {
-            "type": "number"
+        "run_time": {
+            "type": "number",
+            "title": "Run Time",
+            "propertyOrder": 5
         },
-        "Time at Max Compression": {
-            "type": "number"
+        "velocity_at_max_compression": {
+            "type": "number",
+            "title": "Velocity at Max Compression",
+            "propertyOrder": 6
         },
-        "Velocity at Max Tension": {
-            "type": "number"
+        "time_at_max_compression": {
+            "type": "number",
+            "title": "Time at Max Compression",
+            "propertyOrder": 7
         },
-        "Time at Max Tension": {
-            "type": "number"
+        "velocity_at_max_tension": {
+            "type": "number",
+            "title": "Velocity at Max Tension",
+            "propertyOrder": 8
         },
-        "Velocity at Recompression": {
-            "type": "number"
+        "time_at_max_tension": {
+            "type": "number",
+            "title": "Time at Max Tension",
+            "propertyOrder": 9
         },
-        "Time at Recompression": {
-            "type": "number"
+        "velocity_at_recompression": {
+            "type": "number",
+            "title": "Velocity at Recompression",
+            "propertyOrder": 10
         },
-        "Carrier Frequency": {
-            "type": "number"
+        "time_at_recompression": {
+            "type": "number",
+            "title": "Time at Recompression",
+            "propertyOrder": 11
         },
-        "Spall Strength": {
-            "type": "number"
+        "carrier_frequency": {
+            "type": "number",
+            "title": "Carrier Frequency",
+            "propertyOrder": 12
         },
-        "Spall Strength Uncertainty": {
-            "type": "number"
+        "spall_strength": {
+            "type": "number",
+            "title": "Spall Strength",
+            "propertyOrder": 13
         },
-        "Strain Rate": {
-            "type": "number"
+        "spall_strength_uncertainty": {
+            "type": "number",
+            "title": "Spall Strength Uncertainty",
+            "propertyOrder": 14
         },
-        "Strain Rate Uncertainty": {
-            "type": "number"
+        "strain_rate": {
+            "type": "number",
+            "title": "Strain Rate",
+            "propertyOrder": 15
         },
-        "Peak Shock Stress": {
-            "type": "number"
+        "strain_rate_uncertainty": {
+            "type": "number",
+            "title": "Strain Rate Uncertainty",
+            "propertyOrder": 16
         },
-        "Spect Time Res": {
-            "type": "number"
+        "peak_shock_stress": {
+            "type": "number",
+            "title": "Peak Shock Stress",
+            "propertyOrder": 17
         },
-        "Spect Freq Res": {
-            "type": "number"
+        "spect_time_res": {
+            "type": "number",
+            "title": "Spect Time Res",
+            "propertyOrder": 18
         },
-        "Spect Velocity Res": {
-            "type": "number"
+        "spect_freq_res": {
+            "type": "number",
+            "title": "Spect Freq Res",
+            "propertyOrder": 19
         },
-        "Signal Start Time": {
-            "type": "number"
+        "spect_velocity_res": {
+            "type": "number",
+            "title": "Spect Velocity Res",
+            "propertyOrder": 20
         },
-        "Smoothing Characteristic Time": {
-            "type": "number"
+        "signal_start_time": {
+            "type": "number",
+            "title": "Signal Start Time",
+            "propertyOrder": 21
+        },
+        "smoothing_characteristic_time": {
+            "type": "number",
+            "title": "Smoothing Characteristic Time",
+            "propertyOrder": 22
         }
     },
     "required": [
-        "File Name",
-        "Run Time",
-        "Velocity at Max Compression",
-        "Time at Max Compression",
-        "Velocity at Max Tension",
-        "Time at Max Tension",
-        "Velocity at Recompression",
-        "Time at Recompression",
-        "Carrier Frequency",
-        "Spall Strength",
-        "Spall Strength Uncertainty",
-        "Strain Rate",
-        "Strain Rate Uncertainty",
-        "Peak Shock Stress",
-        "Spect Time Res",
-        "Spect Freq Res",
-        "Spect Velocity Res",
-        "Signal Start Time",
-        "Smoothing Characteristic Time"
+        "file_name",
+        "run_time",
+        "velocity_at_max_compression",
+        "time_at_max_compression",
+        "velocity_at_max_tension",
+        "time_at_max_tension",
+        "velocity_at_recompression",
+        "time_at_recompression",
+        "carrier_frequency",
+        "spall_strength",
+        "spall_strength_uncertainty",
+        "strain_rate",
+        "strain_rate_uncertainty",
+        "peak_shock_stress",
+        "spect_time_res",
+        "spect_freq_res",
+        "spect_velocity_res",
+        "signal_start_time",
+        "smoothing_characteristic_time"
     ]
 }

--- a/alpss_results.json
+++ b/alpss_results.json
@@ -35,6 +35,15 @@
             "propertyOrder": 4,
             "title": "Uncertainty OK"
         },
+        "error_msg": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "default": null,
+            "propertyOrder": 5,
+            "title": "Error Message"
+        },
         "Sample_IGSN": {
             "type": [
                 "string",
@@ -52,7 +61,7 @@
                     "debounceTime": 500
                 }
             },
-            "propertyOrder": 5,
+            "propertyOrder": 6,
             "title": "Sample_IGSN"
         },
         "run_time": {
@@ -61,7 +70,7 @@
                 "null"
             ],
             "default": null,
-            "propertyOrder": 6,
+            "propertyOrder": 7,
             "title": "Run Time"
         },
         "velocity_at_max_compression": {
@@ -70,7 +79,7 @@
                 "null"
             ],
             "default": null,
-            "propertyOrder": 7,
+            "propertyOrder": 8,
             "title": "Velocity at Max Compression"
         },
         "time_at_max_compression": {
@@ -79,7 +88,7 @@
                 "null"
             ],
             "default": null,
-            "propertyOrder": 8,
+            "propertyOrder": 9,
             "title": "Time at Max Compression"
         },
         "velocity_at_max_tension": {
@@ -88,7 +97,7 @@
                 "null"
             ],
             "default": null,
-            "propertyOrder": 9,
+            "propertyOrder": 10,
             "title": "Velocity at Max Tension"
         },
         "time_at_max_tension": {
@@ -97,7 +106,7 @@
                 "null"
             ],
             "default": null,
-            "propertyOrder": 10,
+            "propertyOrder": 11,
             "title": "Time at Max Tension"
         },
         "velocity_at_recompression": {
@@ -106,7 +115,7 @@
                 "null"
             ],
             "default": null,
-            "propertyOrder": 11,
+            "propertyOrder": 12,
             "title": "Velocity at Recompression"
         },
         "time_at_recompression": {
@@ -115,7 +124,7 @@
                 "null"
             ],
             "default": null,
-            "propertyOrder": 12,
+            "propertyOrder": 13,
             "title": "Time at Recompression"
         },
         "carrier_frequency": {
@@ -124,7 +133,7 @@
                 "null"
             ],
             "default": null,
-            "propertyOrder": 13,
+            "propertyOrder": 14,
             "title": "Carrier Frequency"
         },
         "spall_strength": {
@@ -133,7 +142,7 @@
                 "null"
             ],
             "default": null,
-            "propertyOrder": 14,
+            "propertyOrder": 15,
             "title": "Spall Strength"
         },
         "spall_strength_uncertainty": {
@@ -142,7 +151,7 @@
                 "null"
             ],
             "default": null,
-            "propertyOrder": 15,
+            "propertyOrder": 16,
             "title": "Spall Strength Uncertainty"
         },
         "strain_rate": {
@@ -151,7 +160,7 @@
                 "null"
             ],
             "default": null,
-            "propertyOrder": 16,
+            "propertyOrder": 17,
             "title": "Strain Rate"
         },
         "strain_rate_uncertainty": {
@@ -160,7 +169,7 @@
                 "null"
             ],
             "default": null,
-            "propertyOrder": 17,
+            "propertyOrder": 18,
             "title": "Strain Rate Uncertainty"
         },
         "peak_shock_stress": {
@@ -169,7 +178,7 @@
                 "null"
             ],
             "default": null,
-            "propertyOrder": 18,
+            "propertyOrder": 19,
             "title": "Peak Shock Stress"
         },
         "spect_time_res": {
@@ -178,7 +187,7 @@
                 "null"
             ],
             "default": null,
-            "propertyOrder": 19,
+            "propertyOrder": 20,
             "title": "Spect Time Res"
         },
         "spect_freq_res": {
@@ -187,7 +196,7 @@
                 "null"
             ],
             "default": null,
-            "propertyOrder": 20,
+            "propertyOrder": 21,
             "title": "Spect Freq Res"
         },
         "spect_velocity_res": {
@@ -196,7 +205,7 @@
                 "null"
             ],
             "default": null,
-            "propertyOrder": 21,
+            "propertyOrder": 22,
             "title": "Spect Velocity Res"
         },
         "signal_start_time": {
@@ -205,7 +214,7 @@
                 "null"
             ],
             "default": null,
-            "propertyOrder": 22,
+            "propertyOrder": 23,
             "title": "Signal Start Time"
         },
         "smoothing_characteristic_time": {
@@ -214,12 +223,12 @@
                 "null"
             ],
             "default": null,
-            "propertyOrder": 23,
+            "propertyOrder": 24,
             "title": "Smoothing Characteristic Time"
         },
         "version": {
             "type": "string",
-            "propertyOrder": 24,
+            "propertyOrder": 25,
             "title": "Version"
         },
         "hel_detected": {
@@ -228,7 +237,7 @@
                 "null"
             ],
             "default": null,
-            "propertyOrder": 25,
+            "propertyOrder": 26,
             "title": "HEL Detected"
         },
         "hel_strength_(gpa)": {
@@ -237,7 +246,7 @@
                 "null"
             ],
             "default": null,
-            "propertyOrder": 26,
+            "propertyOrder": 27,
             "title": "HEL Strength (GPa)"
         },
         "hel_uncertainty_(gpa)": {
@@ -246,7 +255,7 @@
                 "null"
             ],
             "default": null,
-            "propertyOrder": 27,
+            "propertyOrder": 28,
             "title": "HEL Uncertainty (GPa)"
         },
         "hel_free_surface_velocity_(m/s)": {
@@ -255,7 +264,7 @@
                 "null"
             ],
             "default": null,
-            "propertyOrder": 28,
+            "propertyOrder": 29,
             "title": "HEL Free Surface Velocity (m/s)"
         },
         "hel_time_detection_(ns)": {
@@ -264,7 +273,7 @@
                 "null"
             ],
             "default": null,
-            "propertyOrder": 29,
+            "propertyOrder": 30,
             "title": "HEL Time Detection (ns)"
         },
         "hel_consecutive_points": {
@@ -273,7 +282,7 @@
                 "null"
             ],
             "default": null,
-            "propertyOrder": 30,
+            "propertyOrder": 31,
             "title": "HEL Consecutive Points"
         },
         "hel_segment_duration_(ns)": {
@@ -282,7 +291,7 @@
                 "null"
             ],
             "default": null,
-            "propertyOrder": 31,
+            "propertyOrder": 32,
             "title": "HEL Segment Duration (ns)"
         },
         "hel_strain_rate": {
@@ -291,7 +300,7 @@
                 "null"
             ],
             "default": null,
-            "propertyOrder": 32,
+            "propertyOrder": 33,
             "title": "HEL Strain Rate"
         }
     },
@@ -299,6 +308,7 @@
         "velocity_ok",
         "spall_ok",
         "uncertainty_ok",
+        "error_msg",
         "file_name",
         "run_time",
         "velocity_at_max_compression",

--- a/alpss_results.json
+++ b/alpss_results.json
@@ -13,6 +13,7 @@
                 "boolean",
                 "null"
             ],
+            "default": null,
             "propertyOrder": 2,
             "title": "Velocity OK"
         },
@@ -21,6 +22,7 @@
                 "string",
                 "null"
             ],
+            "default": null,
             "description": "Lookup for the IGSN of the sample",
             "format": "autocomplete",
             "options": {
@@ -40,6 +42,7 @@
                 "number",
                 "null"
             ],
+            "default": null,
             "propertyOrder": 4,
             "title": "Run Time"
         },
@@ -48,6 +51,7 @@
                 "number",
                 "null"
             ],
+            "default": null,
             "propertyOrder": 5,
             "title": "Velocity at Max Compression"
         },
@@ -56,6 +60,7 @@
                 "number",
                 "null"
             ],
+            "default": null,
             "propertyOrder": 6,
             "title": "Time at Max Compression"
         },
@@ -64,6 +69,7 @@
                 "number",
                 "null"
             ],
+            "default": null,
             "propertyOrder": 7,
             "title": "Velocity at Max Tension"
         },
@@ -72,6 +78,7 @@
                 "number",
                 "null"
             ],
+            "default": null,
             "propertyOrder": 8,
             "title": "Time at Max Tension"
         },
@@ -80,6 +87,7 @@
                 "number",
                 "null"
             ],
+            "default": null,
             "propertyOrder": 9,
             "title": "Velocity at Recompression"
         },
@@ -88,6 +96,7 @@
                 "number",
                 "null"
             ],
+            "default": null,
             "propertyOrder": 10,
             "title": "Time at Recompression"
         },
@@ -96,6 +105,7 @@
                 "number",
                 "null"
             ],
+            "default": null,
             "propertyOrder": 11,
             "title": "Carrier Frequency"
         },
@@ -104,6 +114,7 @@
                 "number",
                 "null"
             ],
+            "default": null,
             "propertyOrder": 12,
             "title": "Spall Strength"
         },
@@ -112,6 +123,7 @@
                 "number",
                 "null"
             ],
+            "default": null,
             "propertyOrder": 13,
             "title": "Spall Strength Uncertainty"
         },
@@ -120,6 +132,7 @@
                 "number",
                 "null"
             ],
+            "default": null,
             "propertyOrder": 14,
             "title": "Strain Rate"
         },
@@ -128,6 +141,7 @@
                 "number",
                 "null"
             ],
+            "default": null,
             "propertyOrder": 15,
             "title": "Strain Rate Uncertainty"
         },
@@ -136,6 +150,7 @@
                 "number",
                 "null"
             ],
+            "default": null,
             "propertyOrder": 16,
             "title": "Peak Shock Stress"
         },
@@ -144,6 +159,7 @@
                 "number",
                 "null"
             ],
+            "default": null,
             "propertyOrder": 17,
             "title": "Spect Time Res"
         },
@@ -152,6 +168,7 @@
                 "number",
                 "null"
             ],
+            "default": null,
             "propertyOrder": 18,
             "title": "Spect Freq Res"
         },
@@ -160,6 +177,7 @@
                 "number",
                 "null"
             ],
+            "default": null,
             "propertyOrder": 19,
             "title": "Spect Velocity Res"
         },
@@ -168,6 +186,7 @@
                 "number",
                 "null"
             ],
+            "default": null,
             "propertyOrder": 20,
             "title": "Signal Start Time"
         },
@@ -176,6 +195,7 @@
                 "number",
                 "null"
             ],
+            "default": null,
             "propertyOrder": 21,
             "title": "Smoothing Characteristic Time"
         },
@@ -189,6 +209,7 @@
                 "boolean",
                 "null"
             ],
+            "default": null,
             "propertyOrder": 23,
             "title": "HEL Detected"
         },
@@ -197,6 +218,7 @@
                 "number",
                 "null"
             ],
+            "default": null,
             "propertyOrder": 24,
             "title": "HEL Strength (GPa)"
         },
@@ -205,6 +227,7 @@
                 "number",
                 "null"
             ],
+            "default": null,
             "propertyOrder": 25,
             "title": "HEL Uncertainty (GPa)"
         },
@@ -213,6 +236,7 @@
                 "number",
                 "null"
             ],
+            "default": null,
             "propertyOrder": 26,
             "title": "HEL Free Surface Velocity (m/s)"
         },
@@ -221,6 +245,7 @@
                 "number",
                 "null"
             ],
+            "default": null,
             "propertyOrder": 27,
             "title": "HEL Time Detection (ns)"
         },
@@ -229,6 +254,7 @@
                 "number",
                 "null"
             ],
+            "default": null,
             "propertyOrder": 28,
             "title": "HEL Consecutive Points"
         },
@@ -237,6 +263,7 @@
                 "number",
                 "null"
             ],
+            "default": null,
             "propertyOrder": 29,
             "title": "HEL Segment Duration (ns)"
         },
@@ -245,6 +272,7 @@
                 "number",
                 "null"
             ],
+            "default": null,
             "propertyOrder": 30,
             "title": "HEL Strain Rate"
         }

--- a/alpss_results.json
+++ b/alpss_results.json
@@ -308,7 +308,7 @@
         "velocity_ok",
         "spall_ok",
         "uncertainty_ok",
-        "error_msg",
+        "error_message",
         "file_name",
         "run_time",
         "velocity_at_max_compression",

--- a/alpss_results.json
+++ b/alpss_results.json
@@ -1,0 +1,91 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "PDV Result Schema",
+    "type": "object",
+    "properties": {
+        "Date": {
+            "type": "string"
+        },
+        "Time": {
+            "type": "string"
+        },
+        "File Name": {
+            "type": "string"
+        },
+        "Run Time": {
+            "type": "number"
+        },
+        "Velocity at Max Compression": {
+            "type": "number"
+        },
+        "Time at Max Compression": {
+            "type": "number"
+        },
+        "Velocity at Max Tension": {
+            "type": "number"
+        },
+        "Time at Max Tension": {
+            "type": "number"
+        },
+        "Velocity at Recompression": {
+            "type": "number"
+        },
+        "Time at Recompression": {
+            "type": "number"
+        },
+        "Carrier Frequency": {
+            "type": "number"
+        },
+        "Spall Strength": {
+            "type": "number"
+        },
+        "Spall Strength Uncertainty": {
+            "type": "number"
+        },
+        "Strain Rate": {
+            "type": "number"
+        },
+        "Strain Rate Uncertainty": {
+            "type": "number"
+        },
+        "Peak Shock Stress": {
+            "type": "number"
+        },
+        "Spect Time Res": {
+            "type": "number"
+        },
+        "Spect Freq Res": {
+            "type": "number"
+        },
+        "Spect Velocity Res": {
+            "type": "number"
+        },
+        "Signal Start Time": {
+            "type": "number"
+        },
+        "Smoothing Characteristic Time": {
+            "type": "number"
+        }
+    },
+    "required": [
+        "File Name",
+        "Run Time",
+        "Velocity at Max Compression",
+        "Time at Max Compression",
+        "Velocity at Max Tension",
+        "Time at Max Tension",
+        "Velocity at Recompression",
+        "Time at Recompression",
+        "Carrier Frequency",
+        "Spall Strength",
+        "Spall Strength Uncertainty",
+        "Strain Rate",
+        "Strain Rate Uncertainty",
+        "Peak Shock Stress",
+        "Spect Time Res",
+        "Spect Freq Res",
+        "Spect Velocity Res",
+        "Signal Start Time",
+        "Smoothing Characteristic Time"
+    ]
+}

--- a/alpss_results.json
+++ b/alpss_results.json
@@ -3,20 +3,10 @@
     "title": "ALPSS Result Schema",
     "type": "object",
     "properties": {
-        "date": {
-            "type": "string",
-            "title": "Date",
-            "propertyOrder": 1
-        },
-        "time": {
-            "type": "string",
-            "title": "Time",
-            "propertyOrder": 2
-        },
         "file_name": {
             "type": "string",
             "title": "File Name",
-            "propertyOrder": 3
+            "propertyOrder": 1
         },
         "Sample_IGSN": {
             "type": [
@@ -35,102 +25,102 @@
                     "debounceTime": 500
                 }
             },
-            "propertyOrder": 4
+            "propertyOrder": 2
         },
         "run_time": {
             "type": "number",
             "title": "Run Time",
-            "propertyOrder": 5
+            "propertyOrder": 3
         },
         "velocity_at_max_compression": {
             "type": "number",
             "title": "Velocity at Max Compression",
-            "propertyOrder": 6
+            "propertyOrder": 4
         },
         "time_at_max_compression": {
             "type": "number",
             "title": "Time at Max Compression",
-            "propertyOrder": 7
+            "propertyOrder": 5
         },
         "velocity_at_max_tension": {
             "type": "number",
             "title": "Velocity at Max Tension",
-            "propertyOrder": 8
+            "propertyOrder": 6
         },
         "time_at_max_tension": {
             "type": "number",
             "title": "Time at Max Tension",
-            "propertyOrder": 9
+            "propertyOrder": 7
         },
         "velocity_at_recompression": {
             "type": "number",
             "title": "Velocity at Recompression",
-            "propertyOrder": 10
+            "propertyOrder": 8
         },
         "time_at_recompression": {
             "type": "number",
             "title": "Time at Recompression",
-            "propertyOrder": 11
+            "propertyOrder": 9
         },
         "carrier_frequency": {
             "type": "number",
             "title": "Carrier Frequency",
-            "propertyOrder": 12
+            "propertyOrder": 10
         },
         "spall_strength": {
             "type": "number",
             "title": "Spall Strength",
-            "propertyOrder": 13
+            "propertyOrder": 11
         },
         "spall_strength_uncertainty": {
             "type": "number",
             "title": "Spall Strength Uncertainty",
-            "propertyOrder": 14
+            "propertyOrder": 12
         },
         "strain_rate": {
             "type": "number",
             "title": "Strain Rate",
-            "propertyOrder": 15
+            "propertyOrder": 13
         },
         "strain_rate_uncertainty": {
             "type": "number",
             "title": "Strain Rate Uncertainty",
-            "propertyOrder": 16
+            "propertyOrder": 14
         },
         "peak_shock_stress": {
             "type": "number",
             "title": "Peak Shock Stress",
-            "propertyOrder": 17
+            "propertyOrder": 15
         },
         "spect_time_res": {
             "type": "number",
             "title": "Spect Time Res",
-            "propertyOrder": 18
+            "propertyOrder": 16
         },
         "spect_freq_res": {
             "type": "number",
             "title": "Spect Freq Res",
-            "propertyOrder": 19
+            "propertyOrder": 17
         },
         "spect_velocity_res": {
             "type": "number",
             "title": "Spect Velocity Res",
-            "propertyOrder": 20
+            "propertyOrder": 18
         },
         "signal_start_time": {
             "type": "number",
             "title": "Signal Start Time",
-            "propertyOrder": 21
+            "propertyOrder": 19
         },
         "smoothing_characteristic_time": {
             "type": "number",
             "title": "Smoothing Characteristic Time",
-            "propertyOrder": 22
+            "propertyOrder": 20
         },
         "version": {
             "type": "string",
             "title": "Version",
-            "propertyOrder": 23
+            "propertyOrder": 21
         }
     },
     "required": [

--- a/alpss_results.json
+++ b/alpss_results.json
@@ -3,18 +3,18 @@
     "title": "ALPSS Result Schema",
     "type": "object",
     "properties": {
+        "file_name": {
+            "type": "string",
+            "propertyOrder": 1,
+            "title": "File Name"
+        },
         "velocity_ok": {
             "type": [
                 "boolean",
                 "null"
             ],
-            "propertyOrder": 1,
-            "title": "Velocity OK"
-        },
-        "file_name": {
-            "type": "string",
             "propertyOrder": 2,
-            "title": "File Name"
+            "title": "Velocity OK"
         },
         "Sample_IGSN": {
             "type": [

--- a/alpss_results.json
+++ b/alpss_results.json
@@ -3,9 +3,17 @@
     "title": "ALPSS Result Schema",
     "type": "object",
     "properties": {
+        "velocity_ok": {
+            "type": [
+                "boolean",
+                "null"
+            ],
+            "propertyOrder": 1,
+            "title": "Velocity OK"
+        },
         "file_name": {
             "type": "string",
-            "propertyOrder": 1,
+            "propertyOrder": 2,
             "title": "File Name"
         },
         "Sample_IGSN": {
@@ -24,7 +32,7 @@
                     "debounceTime": 500
                 }
             },
-            "propertyOrder": 2,
+            "propertyOrder": 3,
             "title": "Sample_IGSN"
         },
         "run_time": {
@@ -32,7 +40,7 @@
                 "number",
                 "null"
             ],
-            "propertyOrder": 3,
+            "propertyOrder": 4,
             "title": "Run Time"
         },
         "velocity_at_max_compression": {
@@ -40,7 +48,7 @@
                 "number",
                 "null"
             ],
-            "propertyOrder": 4,
+            "propertyOrder": 5,
             "title": "Velocity at Max Compression"
         },
         "time_at_max_compression": {
@@ -48,7 +56,7 @@
                 "number",
                 "null"
             ],
-            "propertyOrder": 5,
+            "propertyOrder": 6,
             "title": "Time at Max Compression"
         },
         "velocity_at_max_tension": {
@@ -56,7 +64,7 @@
                 "number",
                 "null"
             ],
-            "propertyOrder": 6,
+            "propertyOrder": 7,
             "title": "Velocity at Max Tension"
         },
         "time_at_max_tension": {
@@ -64,7 +72,7 @@
                 "number",
                 "null"
             ],
-            "propertyOrder": 7,
+            "propertyOrder": 8,
             "title": "Time at Max Tension"
         },
         "velocity_at_recompression": {
@@ -72,7 +80,7 @@
                 "number",
                 "null"
             ],
-            "propertyOrder": 8,
+            "propertyOrder": 9,
             "title": "Velocity at Recompression"
         },
         "time_at_recompression": {
@@ -80,7 +88,7 @@
                 "number",
                 "null"
             ],
-            "propertyOrder": 9,
+            "propertyOrder": 10,
             "title": "Time at Recompression"
         },
         "carrier_frequency": {
@@ -88,7 +96,7 @@
                 "number",
                 "null"
             ],
-            "propertyOrder": 10,
+            "propertyOrder": 11,
             "title": "Carrier Frequency"
         },
         "spall_strength": {
@@ -96,7 +104,7 @@
                 "number",
                 "null"
             ],
-            "propertyOrder": 11,
+            "propertyOrder": 12,
             "title": "Spall Strength"
         },
         "spall_strength_uncertainty": {
@@ -104,7 +112,7 @@
                 "number",
                 "null"
             ],
-            "propertyOrder": 12,
+            "propertyOrder": 13,
             "title": "Spall Strength Uncertainty"
         },
         "strain_rate": {
@@ -112,7 +120,7 @@
                 "number",
                 "null"
             ],
-            "propertyOrder": 13,
+            "propertyOrder": 14,
             "title": "Strain Rate"
         },
         "strain_rate_uncertainty": {
@@ -120,7 +128,7 @@
                 "number",
                 "null"
             ],
-            "propertyOrder": 14,
+            "propertyOrder": 15,
             "title": "Strain Rate Uncertainty"
         },
         "peak_shock_stress": {
@@ -128,7 +136,7 @@
                 "number",
                 "null"
             ],
-            "propertyOrder": 15,
+            "propertyOrder": 16,
             "title": "Peak Shock Stress"
         },
         "spect_time_res": {
@@ -136,7 +144,7 @@
                 "number",
                 "null"
             ],
-            "propertyOrder": 16,
+            "propertyOrder": 17,
             "title": "Spect Time Res"
         },
         "spect_freq_res": {
@@ -144,7 +152,7 @@
                 "number",
                 "null"
             ],
-            "propertyOrder": 17,
+            "propertyOrder": 18,
             "title": "Spect Freq Res"
         },
         "spect_velocity_res": {
@@ -152,7 +160,7 @@
                 "number",
                 "null"
             ],
-            "propertyOrder": 18,
+            "propertyOrder": 19,
             "title": "Spect Velocity Res"
         },
         "signal_start_time": {
@@ -160,7 +168,7 @@
                 "number",
                 "null"
             ],
-            "propertyOrder": 19,
+            "propertyOrder": 20,
             "title": "Signal Start Time"
         },
         "smoothing_characteristic_time": {
@@ -168,12 +176,12 @@
                 "number",
                 "null"
             ],
-            "propertyOrder": 20,
+            "propertyOrder": 21,
             "title": "Smoothing Characteristic Time"
         },
         "version": {
             "type": "string",
-            "propertyOrder": 21,
+            "propertyOrder": 22,
             "title": "Version"
         },
         "hel_detected": {
@@ -181,7 +189,7 @@
                 "boolean",
                 "null"
             ],
-            "propertyOrder": 22,
+            "propertyOrder": 23,
             "title": "HEL Detected"
         },
         "hel_strength_(gpa)": {
@@ -189,7 +197,7 @@
                 "number",
                 "null"
             ],
-            "propertyOrder": 23,
+            "propertyOrder": 24,
             "title": "HEL Strength (GPa)"
         },
         "hel_uncertainty_(gpa)": {
@@ -197,7 +205,7 @@
                 "number",
                 "null"
             ],
-            "propertyOrder": 24,
+            "propertyOrder": 25,
             "title": "HEL Uncertainty (GPa)"
         },
         "hel_free_surface_velocity_(m/s)": {
@@ -205,7 +213,7 @@
                 "number",
                 "null"
             ],
-            "propertyOrder": 25,
+            "propertyOrder": 26,
             "title": "HEL Free Surface Velocity (m/s)"
         },
         "hel_time_detection_(ns)": {
@@ -213,7 +221,7 @@
                 "number",
                 "null"
             ],
-            "propertyOrder": 26,
+            "propertyOrder": 27,
             "title": "HEL Time Detection (ns)"
         },
         "hel_consecutive_points": {
@@ -221,7 +229,7 @@
                 "number",
                 "null"
             ],
-            "propertyOrder": 27,
+            "propertyOrder": 28,
             "title": "HEL Consecutive Points"
         },
         "hel_segment_duration_(ns)": {
@@ -229,7 +237,7 @@
                 "number",
                 "null"
             ],
-            "propertyOrder": 28,
+            "propertyOrder": 29,
             "title": "HEL Segment Duration (ns)"
         },
         "hel_strain_rate": {
@@ -237,11 +245,12 @@
                 "number",
                 "null"
             ],
-            "propertyOrder": 29,
+            "propertyOrder": 30,
             "title": "HEL Strain Rate"
         }
     },
     "required": [
+        "velocity_ok",
         "file_name",
         "run_time",
         "velocity_at_max_compression",

--- a/laser_shock_parameters.json
+++ b/laser_shock_parameters.json
@@ -256,7 +256,7 @@
             ],
             "title": "Location",
             "propertyOrder": 30
-        },
+        }
     },
     "required": [
         "Timestamp",

--- a/laser_shock_parameters.json
+++ b/laser_shock_parameters.json
@@ -224,6 +224,38 @@
             ],
             "title": "Notes",
             "propertyOrder": 26
+        },
+        "Performed_by": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "title": "Performed By",
+            "propertyOrder": 27
+        },
+        "Grant": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "title": "Grant",
+            "propertyOrder": 28
+        },
+        "Location": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "title": "Location",
+            "propertyOrder": 29
+        },
+        "Experiment_type": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "title": "Experiment type",
+            "propertyOrder": 30
         }
     },
     "required": [
@@ -252,7 +284,11 @@
         "Laser_Target_Energy_mJ",
         "Beam_Profile_FileName",
         "Shot_Time_seconds",
-        "Notes"
+        "Notes",
+        "Performed_by",
+        "Grant",
+        "Location",
+        "Experiment_type"
     ],
-    "additionalProperties": false
+    "additionalProperties": true
 }

--- a/laser_shock_parameters.json
+++ b/laser_shock_parameters.json
@@ -5,147 +5,241 @@
     "type": "object",
     "properties": {
         "Timestamp": {
-            "type": "string",
+            "type": [
+                "string",
+                "null"
+            ],
             "format": "date-time",
             "title": "Timestamp",
             "propertyOrder": 1
         },
         "Exp_ID": {
-            "type": "integer",
+            "type": [
+                "number",
+                "null"
+            ],
             "title": "Exp_ID",
             "propertyOrder": 2
         },
         "Flyer_ID": {
-            "type": "string",
+            "type": [
+                "string",
+                "null"
+            ],
             "title": "Flyer_ID",
             "propertyOrder": 3
         },
         "Flyer_material": {
-            "type": "string",
+            "type": [
+                "string",
+                "null"
+            ],
             "title": "Flyer_material",
             "propertyOrder": 4
         },
         "Flyer_Thickness_um": {
-            "type": "integer",
+            "type": [
+                "number",
+                "null"
+            ],
             "title": "Flyer_Thickness (um)",
             "propertyOrder": 5
         },
         "Sample_ID": {
-            "type": "string",
+            "type": [
+                "string",
+                "null"
+            ],
             "title": "Sample_ID",
             "description": "Lookup for the IGSN of the sample",
             "format": "autocomplete",
             "options": {
-              "autocomplete": {
-                "search": "search_deposition",
-                "renderResult": "render_deposition",
-                "getResultValue": "get_deposition_value",
-                "autoSelect": true,
-                "debounceTime": 500
-              }
+                "autocomplete": {
+                    "search": "search_deposition",
+                    "renderResult": "render_deposition",
+                    "getResultValue": "get_deposition_value",
+                    "autoSelect": true,
+                    "debounceTime": 500
+                }
             },
             "propertyOrder": 6
         },
         "Sample_material": {
-            "type": "string",
+            "type": [
+                "string",
+                "null"
+            ],
             "title": "Sample material",
             "propertyOrder": 7
         },
         "Spacing_um": {
-            "type": "integer",
+            "type": [
+                "number",
+                "null"
+            ],
             "title": "Spacing (um)",
             "propertyOrder": 8
         },
         "Waveplate_Angle_Degrees": {
-            "type": "integer",
+            "type": [
+                "number",
+                "null"
+            ],
             "title": "Waveplate_Angle (Degrees)",
             "propertyOrder": 9
         },
         "PDV_FileName": {
-            "type": "string",
+            "type": [
+                "string",
+                "null"
+            ],
             "title": "PDV_FileName",
             "pattern": "^[^\\s]+$",
             "propertyOrder": 10
         },
         "PDV_Target_Wavelength_m": {
-            "type": "number",
+            "type": [
+                "number",
+                "null"
+            ],
             "title": "PDV_Target_Wavelength (m)",
             "propertyOrder": 11
         },
         "PDV_Target_Power_dBm": {
-            "type": "number",
+            "type": [
+                "number",
+                "null"
+            ],
             "title": "PDV_Target_Power (dBm)",
             "propertyOrder": 12
         },
         "PDV_Ref_Wavelength_m": {
-            "type": "number",
+            "type": [
+                "number",
+                "null"
+            ],
             "title": "PDV_Ref_Wavelength (m)",
             "propertyOrder": 13
         },
         "PDV_Ref_Power_dBm": {
-            "type": "number",
+            "type": [
+                "number",
+                "null"
+            ],
             "title": "PDV_Ref_Power (dBm)",
             "propertyOrder": 14
         },
         "PDV_Return_Power_dBm": {
-            "type": "number",
+            "type": [
+                "number",
+                "null"
+            ],
             "title": "PDV_Return_Power (dBm)",
             "propertyOrder": 15
         },
         "Flyer_Row": {
-            "type": "integer",
+            "type": [
+                "number",
+                "null"
+            ],
             "title": "Flyer_Row",
             "propertyOrder": 16
         },
         "Flyer_Column": {
-            "type": "integer",
+            "type": [
+                "number",
+                "null"
+            ],
             "title": "Flyer_Column",
             "propertyOrder": 17
         },
         "Flyer_X_Position_Desired_mm": {
-            "type": "number",
+            "type": [
+                "number",
+                "null"
+            ],
             "title": "Flyer_X_Position_Desired (mm)",
             "propertyOrder": 18
         },
         "Flyer_Y_Position_Desired_mm": {
-            "type": "number",
+            "type": [
+                "number",
+                "null"
+            ],
             "title": "Flyer_Y_Position_Desired (mm)",
             "propertyOrder": 19
         },
-        "Flyer_X_Position_Corrected_mm": {
-            "type": "number",
-            "title": "Flyer_X_Position_Corrected (mm)",
+        "Flyer_X_Position_Final_mm": {
+            "type": [
+                "number",
+                "null"
+            ],
+            "title": "Flyer_X_Position_Final (mm)",
             "propertyOrder": 20
         },
-        "Flyer_Y_Position_Corrected_mm": {
-            "type": "number",
-            "title": "Flyer_Y_Position_Corrected (mm)",
+        "Flyer_Y_Position_Final_mm": {
+            "type": [
+                "number",
+                "null"
+            ],
+            "title": "Flyer_Y_Position_Final (mm)",
             "propertyOrder": 21
         },
-        "Laser_Ref_Energy_mJ": {
-            "type": "number",
-            "title": "Laser_Ref_Energy (mJ)",
+        "Flyer_X_Position_Corrected_mm": {
+            "type": [
+                "number",
+                "null"
+            ],
+            "title": "Flyer_X_Position_Corrected (mm)",
             "propertyOrder": 22
         },
-        "Laser_Target_Energy_mJ": {
-            "type": "number",
-            "title": "Laser_Target_Energy (mJ)",
+        "Flyer_Y_Position_Corrected_mm": {
+            "type": [
+                "number",
+                "null"
+            ],
+            "title": "Flyer_Y_Position_Corrected (mm)",
             "propertyOrder": 23
         },
-        "Beam_Profile_FileName": {
-            "type": "string",
-            "title": "Beam_Profile_FileName",
+        "Laser_Ref_Energy_mJ": {
+            "type": [
+                "number",
+                "null"
+            ],
+            "title": "Laser_Ref_Energy (mJ)",
             "propertyOrder": 24
         },
-        "Shot_Time_seconds": {
-            "type": "number",
-            "title": "Shot_Time (seconds)",
+        "Laser_Target_Energy_mJ": {
+            "type": [
+                "number",
+                "null"
+            ],
+            "title": "Laser_Target_Energy (mJ)",
             "propertyOrder": 25
         },
-        "Notes": {
-            "type": "string",
-            "title": "Notes",
+        "Beam_Profile_FileName": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "title": "Beam_Profile_FileName",
             "propertyOrder": 26
+        },
+        "Shot_Time_seconds": {
+            "type": [
+                "number",
+                "null"
+            ],
+            "title": "Shot_Time (seconds)",
+            "propertyOrder": 27
+        },
+        "Notes": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "title": "Notes",
+            "propertyOrder": 28
         }
     },
     "required": [
@@ -168,6 +262,8 @@
         "Flyer_Column",
         "Flyer_X_Position_Desired_mm",
         "Flyer_Y_Position_Desired_mm",
+        "Flyer_X_Position_Final_mm",
+        "Flyer_Y_Position_Final_mm",
         "Flyer_X_Position_Corrected_mm",
         "Flyer_Y_Position_Corrected_mm",
         "Laser_Ref_Energy_mJ",

--- a/laser_shock_parameters.json
+++ b/laser_shock_parameters.json
@@ -53,12 +53,12 @@
             "title": "Flyer_Thickness (um)",
             "propertyOrder": 6
         },
-        "Sample_ID": {
+        "sample_IGSN": {
             "type": [
                 "string",
                 "null"
             ],
-            "title": "Sample_ID",
+            "title": "sample_IGSN",
             "description": "Lookup for the IGSN of the sample",
             "format": "autocomplete",
             "options": {
@@ -265,7 +265,7 @@
         "Flyer_ID",
         "Flyer_material",
         "Flyer_Thickness_um",
-        "Sample_ID",
+        "sample_IGSN",
         "Sample_material",
         "Spacing_um",
         "Waveplate_Angle_Degrees",

--- a/laser_shock_parameters.json
+++ b/laser_shock_parameters.json
@@ -21,13 +21,21 @@
             "title": "Exp_ID",
             "propertyOrder": 2
         },
+        "Experiment_type": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "title": "Experiment type",
+            "propertyOrder": 3
+        },
         "Flyer_ID": {
             "type": [
                 "string",
                 "null"
             ],
             "title": "Flyer_ID",
-            "propertyOrder": 3
+            "propertyOrder": 4
         },
         "Flyer_material": {
             "type": [
@@ -35,7 +43,7 @@
                 "null"
             ],
             "title": "Flyer_material",
-            "propertyOrder": 4
+            "propertyOrder": 5
         },
         "Flyer_Thickness_um": {
             "type": [
@@ -43,7 +51,7 @@
                 "null"
             ],
             "title": "Flyer_Thickness (um)",
-            "propertyOrder": 5
+            "propertyOrder": 6
         },
         "Sample_ID": {
             "type": [
@@ -62,7 +70,7 @@
                     "debounceTime": 500
                 }
             },
-            "propertyOrder": 6
+            "propertyOrder": 7
         },
         "Sample_material": {
             "type": [
@@ -70,7 +78,7 @@
                 "null"
             ],
             "title": "Sample material",
-            "propertyOrder": 7
+            "propertyOrder": 8
         },
         "Spacing_um": {
             "type": [
@@ -78,7 +86,7 @@
                 "null"
             ],
             "title": "Spacing (um)",
-            "propertyOrder": 8
+            "propertyOrder": 9
         },
         "Waveplate_Angle_Degrees": {
             "type": [
@@ -86,7 +94,7 @@
                 "null"
             ],
             "title": "Waveplate_Angle (Degrees)",
-            "propertyOrder": 9
+            "propertyOrder": 10
         },
         "PDV_FileName": {
             "type": [
@@ -95,7 +103,7 @@
             ],
             "title": "PDV_FileName",
             "pattern": "^[^\\s]+$",
-            "propertyOrder": 10
+            "propertyOrder": 11
         },
         "PDV_Target_Wavelength_m": {
             "type": [
@@ -103,7 +111,7 @@
                 "null"
             ],
             "title": "PDV_Target_Wavelength (m)",
-            "propertyOrder": 11
+            "propertyOrder": 12
         },
         "PDV_Target_Power_dBm": {
             "type": [
@@ -111,7 +119,7 @@
                 "null"
             ],
             "title": "PDV_Target_Power (dBm)",
-            "propertyOrder": 12
+            "propertyOrder": 13
         },
         "PDV_Ref_Wavelength_m": {
             "type": [
@@ -119,7 +127,7 @@
                 "null"
             ],
             "title": "PDV_Ref_Wavelength (m)",
-            "propertyOrder": 13
+            "propertyOrder": 14
         },
         "PDV_Ref_Power_dBm": {
             "type": [
@@ -127,7 +135,7 @@
                 "null"
             ],
             "title": "PDV_Ref_Power (dBm)",
-            "propertyOrder": 14
+            "propertyOrder": 15
         },
         "PDV_Return_Power_dBm": {
             "type": [
@@ -135,7 +143,7 @@
                 "null"
             ],
             "title": "PDV_Return_Power (dBm)",
-            "propertyOrder": 15
+            "propertyOrder": 16
         },
         "Flyer_Row": {
             "type": [
@@ -143,7 +151,7 @@
                 "null"
             ],
             "title": "Flyer_Row",
-            "propertyOrder": 16
+            "propertyOrder": 17
         },
         "Flyer_Column": {
             "type": [
@@ -151,7 +159,7 @@
                 "null"
             ],
             "title": "Flyer_Column",
-            "propertyOrder": 17
+            "propertyOrder": 18
         },
         "Flyer_X_Position_Desired_mm": {
             "type": [
@@ -159,7 +167,7 @@
                 "null"
             ],
             "title": "Flyer_X_Position_Desired (mm)",
-            "propertyOrder": 18
+            "propertyOrder": 19
         },
         "Flyer_Y_Position_Desired_mm": {
             "type": [
@@ -167,7 +175,7 @@
                 "null"
             ],
             "title": "Flyer_Y_Position_Desired (mm)",
-            "propertyOrder": 19
+            "propertyOrder": 20
         },
         "Flyer_X_Position_Final_mm": {
             "type": [
@@ -175,7 +183,7 @@
                 "null"
             ],
             "title": "Flyer_X_Position_Final (mm)",
-            "propertyOrder": 20
+            "propertyOrder": 21
         },
         "Flyer_Y_Position_Final_mm": {
             "type": [
@@ -183,7 +191,7 @@
                 "null"
             ],
             "title": "Flyer_Y_Position_Final (mm)",
-            "propertyOrder": 21
+            "propertyOrder": 22
         },
         "Laser_Ref_Energy_mJ": {
             "type": [
@@ -191,7 +199,7 @@
                 "null"
             ],
             "title": "Laser_Ref_Energy (mJ)",
-            "propertyOrder": 22
+            "propertyOrder": 23
         },
         "Laser_Target_Energy_mJ": {
             "type": [
@@ -199,7 +207,7 @@
                 "null"
             ],
             "title": "Laser_Target_Energy (mJ)",
-            "propertyOrder": 23
+            "propertyOrder": 24
         },
         "Beam_Profile_FileName": {
             "type": [
@@ -207,7 +215,7 @@
                 "null"
             ],
             "title": "Beam_Profile_FileName",
-            "propertyOrder": 24
+            "propertyOrder": 25
         },
         "Shot_Time_seconds": {
             "type": [
@@ -215,7 +223,7 @@
                 "null"
             ],
             "title": "Shot_Time (seconds)",
-            "propertyOrder": 25
+            "propertyOrder": 26
         },
         "Notes": {
             "type": [
@@ -223,7 +231,7 @@
                 "null"
             ],
             "title": "Notes",
-            "propertyOrder": 26
+            "propertyOrder": 27
         },
         "Performed_by": {
             "type": [
@@ -231,7 +239,7 @@
                 "null"
             ],
             "title": "Performed By",
-            "propertyOrder": 27
+            "propertyOrder": 28
         },
         "Grant": {
             "type": [
@@ -239,7 +247,7 @@
                 "null"
             ],
             "title": "Grant",
-            "propertyOrder": 28
+            "propertyOrder": 29
         },
         "Location": {
             "type": [
@@ -247,20 +255,13 @@
                 "null"
             ],
             "title": "Location",
-            "propertyOrder": 29
-        },
-        "Experiment_type": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "title": "Experiment type",
             "propertyOrder": 30
-        }
+        },
     },
     "required": [
         "Timestamp",
         "Exp_ID",
+        "Experiment_type",
         "Flyer_ID",
         "Flyer_material",
         "Flyer_Thickness_um",
@@ -288,7 +289,6 @@
         "Performed_by",
         "Grant",
         "Location",
-        "Experiment_type"
     ],
     "additionalProperties": true
 }

--- a/laser_shock_parameters.json
+++ b/laser_shock_parameters.json
@@ -185,29 +185,13 @@
             "title": "Flyer_Y_Position_Final (mm)",
             "propertyOrder": 21
         },
-        "Flyer_X_Position_Corrected_mm": {
-            "type": [
-                "number",
-                "null"
-            ],
-            "title": "Flyer_X_Position_Corrected (mm)",
-            "propertyOrder": 22
-        },
-        "Flyer_Y_Position_Corrected_mm": {
-            "type": [
-                "number",
-                "null"
-            ],
-            "title": "Flyer_Y_Position_Corrected (mm)",
-            "propertyOrder": 23
-        },
         "Laser_Ref_Energy_mJ": {
             "type": [
                 "number",
                 "null"
             ],
             "title": "Laser_Ref_Energy (mJ)",
-            "propertyOrder": 24
+            "propertyOrder": 22
         },
         "Laser_Target_Energy_mJ": {
             "type": [
@@ -215,7 +199,7 @@
                 "null"
             ],
             "title": "Laser_Target_Energy (mJ)",
-            "propertyOrder": 25
+            "propertyOrder": 23
         },
         "Beam_Profile_FileName": {
             "type": [
@@ -223,7 +207,7 @@
                 "null"
             ],
             "title": "Beam_Profile_FileName",
-            "propertyOrder": 26
+            "propertyOrder": 24
         },
         "Shot_Time_seconds": {
             "type": [
@@ -231,7 +215,7 @@
                 "null"
             ],
             "title": "Shot_Time (seconds)",
-            "propertyOrder": 27
+            "propertyOrder": 25
         },
         "Notes": {
             "type": [
@@ -239,7 +223,7 @@
                 "null"
             ],
             "title": "Notes",
-            "propertyOrder": 28
+            "propertyOrder": 26
         }
     },
     "required": [
@@ -264,8 +248,6 @@
         "Flyer_Y_Position_Desired_mm",
         "Flyer_X_Position_Final_mm",
         "Flyer_Y_Position_Final_mm",
-        "Flyer_X_Position_Corrected_mm",
-        "Flyer_Y_Position_Corrected_mm",
         "Laser_Ref_Energy_mJ",
         "Laser_Target_Energy_mJ",
         "Beam_Profile_FileName",

--- a/laser_shock_parameters.json
+++ b/laser_shock_parameters.json
@@ -288,7 +288,7 @@
         "Notes",
         "Performed_by",
         "Grant",
-        "Location",
+        "Location"
     ],
     "additionalProperties": true
 }

--- a/laser_shock_parameters.json
+++ b/laser_shock_parameters.json
@@ -21,12 +21,12 @@
             "title": "Exp_ID",
             "propertyOrder": 2
         },
-        "Experiment_type": {
+        "Exp_type": {
             "type": [
                 "string",
                 "null"
             ],
-            "title": "Experiment type",
+            "title": "Exp_type",
             "propertyOrder": 3
         },
         "Flyer_ID": {
@@ -238,7 +238,7 @@
                 "string",
                 "null"
             ],
-            "title": "Performed By",
+            "title": "Performed_by",
             "propertyOrder": 28
         },
         "Grant": {
@@ -261,7 +261,7 @@
     "required": [
         "Timestamp",
         "Exp_ID",
-        "Experiment_type",
+        "Exp_type",
         "Flyer_ID",
         "Flyer_material",
         "Flyer_Thickness_um",


### PR DESCRIPTION
## Changes

**alpss_results.json** (updated schema)
- Added quality flags: `velocity_ok`, `spall_ok`, `hel_detected`
- Added `error_message` field to capture partial failures
- Added 8 HEL fields: `hel_strength_(gpa)`, `hel_uncertainty_(gpa)`, `hel_free_surface_velocity_(m/s)`, `hel_time_detection_(ns)`, `hel_consecutive_points`, `hel_segment_duration_(ns)`, `hel_strain_rate` — all optional with null defaults
- Fields use nullable types (`["number", "null"]`) for graceful handling of failed analyses

**laser_shock_parameters.json**
-   Followed changes made by Laser Shock team and added "Notes", "Performed_by", "Grant", "Location", and "Exp_type"
- Renamed `Sample_ID` to `Sample_IGSN` per Eric's request