### PR TITLE
AIMD-L batch IGSN registration form

### DIFF
--- a/aimdl_batch_igsns.js
+++ b/aimdl_batch_igsns.js
@@ -17,6 +17,17 @@ window.JSONEditor.defaults.callbacks.autocomplete = {
             url: 'deposition',
             method: 'GET',
             data: { q: input, limit: 10 }
+        }).then(function (results) {
+            return results.filter(function (result) {
+                try {
+                    const localId = result.metadata.alternateIdentifiers.find(
+                        (id) => id.alternateIdentifierType.toLowerCase() === 'local'
+                    );
+                    return localId && localId.alternateIdentifier.startsWith('Sheet_');
+                } catch (e) {
+                    return false;
+                }
+            });
         });
     },
     'render_deposition': function (editor, result, props) {

--- a/aimdl_batch_igsns.js
+++ b/aimdl_batch_igsns.js
@@ -1,3 +1,42 @@
 Handlebars.registerHelper('replaceAll', function (string, search, replacement) {
     return (string !== undefined && string !== null) ? string.replaceAll(search, replacement) : '';
 });
+
+Handlebars.registerHelper('split', function (string, separator, index) {
+    try {
+        return string.split(separator)[index].trim();
+    } catch (e) {
+        return '';
+    }
+});
+
+window.JSONEditor.defaults.callbacks.autocomplete = {
+    'search_deposition': function (editor, input) {
+        if (input.length < 3) return [];
+        return restRequest({
+            url: 'deposition',
+            method: 'GET',
+            data: { q: input, limit: 10 }
+        });
+    },
+    'render_deposition': function (editor, result, props) {
+        try {
+            const localId = result.metadata.alternateIdentifiers.find(
+                (id) => id.alternateIdentifierType.toLowerCase() === 'local'
+            );
+            return `<li ${props}>${result.igsn} (localId: ${localId.alternateIdentifier})</li>`;
+        } catch (e) {
+            return `<li ${props}>${result.igsn} (title: ${result.metadata.titles[0]['title']})</li>`;
+        }
+    },
+    'get_deposition_value': function (editor, result) {
+        try {
+            const localId = result.metadata.alternateIdentifiers.find(
+                (id) => id.alternateIdentifierType.toLowerCase() === 'local'
+            );
+            return `${result.igsn} - ${result._id} - ${localId.alternateIdentifier}`;
+        } catch (e) {
+            return `${result.igsn} - ${result._id} - no localId`;
+        }
+    }
+};

--- a/aimdl_batch_igsns.js
+++ b/aimdl_batch_igsns.js
@@ -1,0 +1,3 @@
+Handlebars.registerHelper('replaceAll', function (string, search, replacement) {
+    return (string !== undefined && string !== null) ? string.replaceAll(search, replacement) : '';
+});

--- a/aimdl_batch_igsns.json
+++ b/aimdl_batch_igsns.json
@@ -526,19 +526,30 @@
         }
       }
     },
+    "photo": {
+      "title": "Photo",
+      "description": "Upload a photo of the sheet.",
+      "$ref": "#/definitions/fileUpload",
+      "propertyOrder": 13,
+      "options": {
+        "dependencies": {
+          "sheetIGSNMode": "create"
+        }
+      }
+    },
     "createSampleIGSNs": {
       "title": "Create Sample IGSNs",
       "description": "Check to mint IGSNs for the cut samples from this sheet.",
       "type": "boolean",
       "format": "checkbox",
       "default": true,
-      "propertyOrder": 13
+      "propertyOrder": 14
     },
     "sampleCount": {
       "title": "Number of Samples",
       "description": "How many samples to cut from this sheet. One IGSN will be minted per sample (suffixed -1, -2, ...).",
       "type": "integer",
-      "propertyOrder": 14,
+      "propertyOrder": 15,
       "options": {
         "dependencies": {
           "createSampleIGSNs": true
@@ -550,7 +561,7 @@
       "description": "Description applied uniformly to all cut samples from this sheet.",
       "type": "string",
       "format": "textarea",
-      "propertyOrder": 15,
+      "propertyOrder": 16,
       "options": {
         "dependencies": {
           "createSampleIGSNs": true
@@ -585,7 +596,7 @@
           "options": { "grid_columns": 4 }
         }
       },
-      "propertyOrder": 16,
+      "propertyOrder": 17,
       "options": {
         "dependencies": {
           "createSampleIGSNs": true

--- a/aimdl_batch_igsns.json
+++ b/aimdl_batch_igsns.json
@@ -437,14 +437,24 @@
       "description": "How many samples to cut from this sheet. One IGSN will be minted per sample (suffixed -1, -2, ...).",
       "type": "integer",
       "minimum": 1,
-      "propertyOrder": 14
+      "propertyOrder": 14,
+      "options": {
+        "dependencies": {
+          "createSampleIGSNs": true
+        }
+      }
     },
     "sampleDescription": {
       "title": "Sample Description",
       "description": "Description applied uniformly to all cut samples from this sheet.",
       "type": "string",
       "format": "textarea",
-      "propertyOrder": 15
+      "propertyOrder": 15,
+      "options": {
+        "dependencies": {
+          "createSampleIGSNs": true
+        }
+      }
     },
     "sampleDimensions": {
       "title": "Sample Dimensions (mm)",
@@ -471,7 +481,12 @@
           "options": { "grid_columns": 4 }
         }
       },
-      "propertyOrder": 16
+      "propertyOrder": 16,
+      "options": {
+        "dependencies": {
+          "createSampleIGSNs": true
+        }
+      }
     }
   },
   "required": [
@@ -481,37 +496,19 @@
     "uniqueNumber",
     "sampleCount"
   ],
-  "allOf": [
-    {
-      "if": {
+  "if": {
+    "properties": {
+      "igsn": {
         "properties": {
-          "igsn": {
-            "properties": {
-              "request": { "const": false }
-            }
-          }
-        }
-      },
-      "then": {
-        "properties": {
-          "igsnMeta": { "options": { "hidden": true }, "readonly": true },
-          "assignedIGSN": { "options": { "hidden": false }, "readonly": true }
-        }
-      }
-    },
-    {
-      "if": {
-        "properties": {
-          "createSampleIGSNs": { "const": false }
-        }
-      },
-      "then": {
-        "properties": {
-          "sampleCount": { "options": { "hidden": true } },
-          "sampleDescription": { "options": { "hidden": true } },
-          "sampleDimensions": { "options": { "hidden": true } }
+          "request": { "const": false }
         }
       }
     }
-  ]
+  },
+  "then": {
+    "properties": {
+      "igsnMeta": { "options": { "hidden": true }, "readonly": true },
+      "assignedIGSN": { "options": { "hidden": false }, "readonly": true }
+    }
+  }
 }

--- a/aimdl_batch_igsns.json
+++ b/aimdl_batch_igsns.json
@@ -436,7 +436,6 @@
       "title": "Number of Samples",
       "description": "How many samples to cut from this sheet. One IGSN will be minted per sample (suffixed -1, -2, ...).",
       "type": "integer",
-      "minimum": 1,
       "propertyOrder": 14,
       "options": {
         "dependencies": {
@@ -493,8 +492,7 @@
     "projectIdentifier",
     "date",
     "alloy",
-    "uniqueNumber",
-    "sampleCount"
+    "uniqueNumber"
   ],
   "if": {
     "properties": {

--- a/aimdl_batch_igsns.json
+++ b/aimdl_batch_igsns.json
@@ -1,0 +1,306 @@
+{
+  "title": "AIMD-L Batch IGSNs",
+  "description": "Sheet and batch sample IGSN registration for AIMD-L",
+  "type": "object",
+  "definitions": {
+    "igsnMetadata": {
+      "id": "igsnMetadata",
+      "type": "object",
+      "format": "grid-strict",
+      "title": "Sample IGSN Creation",
+      "options": {
+        "grid_columns": 12,
+        "titleHidden": true
+      },
+      "properties": {
+        "_text1": {
+          "format": "hidden",
+          "type": "string",
+          "title": "IGSN metadata",
+          "description": "<p>This section gathers necessary information to create an IGSN for the sheet</p>",
+          "propertyOrder": 0,
+          "options": {
+            "grid_columns": 12,
+            "grid_break": true
+          }
+        },
+        "institution": {
+          "type": "string",
+          "description": "Originating Institution",
+          "enum": [
+            "JHU"
+          ],
+          "default": "JHU",
+          "propertyOrder": 1,
+          "options": {
+            "titleHidden": true,
+            "grid_columns": 3,
+            "enum_titles": [
+              "Johns Hopkins University"
+            ]
+          }
+        },
+        "groupJHU": {
+          "type": "string",
+          "description": "Group within the institution",
+          "enum": [
+            "X"
+          ],
+          "default": "X",
+          "propertyOrder": 2,
+          "options": {
+            "titleHidden": true,
+            "grid_columns": 3,
+            "enum_titles": [
+              "Unknown"
+            ]
+          }
+        },
+        "material": {
+          "type": "string",
+          "description": "Material Type",
+          "enum": [
+            "MA"
+          ],
+          "default": "MA",
+          "propertyOrder": 3,
+          "options": {
+            "titleHidden": true,
+            "grid_columns": 3,
+            "enum_titles": [
+              "metals and alloys"
+            ]
+          }
+        },
+        "submaterialMA": {
+          "type": "string",
+          "description": "Material Subtype",
+          "enum": [
+            "A",
+            "B",
+            "C",
+            "D",
+            "E",
+            "F",
+            "G",
+            "H",
+            "I",
+            "J",
+            "K",
+            "L"
+          ],
+          "propertyOrder": 4,
+          "default": "L",
+          "options": {
+            "titleHidden": true,
+            "dependencies": {
+              "material": "MA"
+            },
+            "enum_titles": [
+              "Al-containing",
+              "commercially pure metals",
+              "Cu-containing",
+              "Fe-containing",
+              "intermetallics",
+              "Mg-containing",
+              "Ni-containing",
+              "rare earth",
+              "refactories",
+              "steels",
+              "superalloys",
+              "Ti-containing"
+            ],
+            "grid_columns": 3,
+            "grid_break": true
+          }
+        },
+        "title": {
+          "type": "string",
+          "title": "Sample Name",
+          "readOnly": true,
+          "propertyOrder": 5,
+          "options": {
+            "grid_columns": 12,
+            "titleHidden": true,
+            "hidden": true
+          }
+        },
+        "attributes": {
+          "type": "object",
+          "propertyOrder": 6,
+          "properties": {
+            "alternateIdentifiers": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "object",
+                "properties": {
+                  "alternateIdentifier": {
+                    "type": "string",
+                    "propertyOrder": 1,
+                    "watch": {
+                      "sampleId": "root.sheetID"
+                    },
+                    "template": "{{sampleId}}"
+                  },
+                  "alternateIdentifierType": {
+                    "type": "string",
+                    "propertyOrder": 2,
+                    "default": "local"
+                  }
+                }
+              }
+            }
+          },
+          "options": {
+            "grid_columns": 12,
+            "grid_break": true,
+            "hidden": true
+          }
+        }
+      }
+    },
+    "igsn": {
+      "id": "igsn",
+      "type": "object",
+      "format": "grid-strict",
+      "title": "Sample IGSN Creation",
+      "options": {
+        "grid_columns": 12,
+        "titleHidden": true
+      },
+      "properties": {
+        "suffix": {
+          "type": "string",
+          "propertyOrder": 1,
+          "options": {
+            "hidden": true,
+            "grid_columns": 12
+          },
+          "default": ""
+        },
+        "prefix": {
+          "type": "string",
+          "propertyOrder": 2,
+          "description": "The unique identifier for the sheet.",
+          "hidden": true,
+          "template": "{{org}}{{gJHU}}{{material}}{{sMA}}",
+          "watch": {
+            "org": "root.igsnMeta.institution",
+            "gJHU": "root.igsnMeta.groupJHU",
+            "material": "root.igsnMeta.material",
+            "sMA": "root.igsnMeta.submaterialMA"
+          },
+          "options": {
+            "grid_columns": 12,
+            "hidden": true
+          }
+        },
+        "request": {
+          "type": "boolean",
+          "propertyOrder": 3,
+          "title": "Request IGSN",
+          "description": "Whether to request an IGSN.",
+          "default": true,
+          "options": {
+            "hidden": true,
+            "grid_columns": 12
+          }
+        },
+        "track": {
+          "type": "boolean",
+          "propertyOrder": 4,
+          "title": "Track IGSN",
+          "description": "Whether to create Sample tracking.",
+          "default": true,
+          "options": {
+            "hidden": true,
+            "grid_columns": 12
+          }
+        },
+        "field": {
+          "type": "string",
+          "propertyOrder": 5,
+          "title": "Field with IGSN prefix",
+          "const": "assignedIGSN",
+          "default": "assignedIGSN",
+          "options": {
+            "hidden": true,
+            "grid_columns": 12
+          }
+        },
+        "batch": {
+          "type": "object",
+          "propertyOrder": 6,
+          "properties": {
+            "method": {
+              "type": "string",
+              "propertyOrder": 1,
+              "title": "Batching Method",
+              "default": "aimdl",
+              "options": {
+                "hidden": true
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "properties": {
+    "assignedIGSN": {
+      "type": "string",
+      "propertyOrder": 0,
+      "template": "{{prefix}}{{suffix}}",
+      "watch": {
+        "prefix": "igsn.prefix",
+        "suffix": "igsn.suffix"
+      },
+      "options": {
+        "hidden": true,
+        "grid_columns": 12
+      }
+    },
+    "igsnMeta": {
+      "$ref": "#/definitions/igsnMetadata",
+      "propertyOrder": 0,
+      "options": {
+        "hidden": false
+      }
+    },
+    "igsn": {
+      "$ref": "#/definitions/igsn",
+      "propertyOrder": 0,
+      "options": {
+        "hidden": true
+      }
+    }
+  },
+  "if": {
+    "properties": {
+      "igsn": {
+        "properties": {
+          "request": {
+            "const": false
+          }
+        }
+      }
+    }
+  },
+  "then": {
+    "properties": {
+      "igsnMeta": {
+        "options": {
+          "hidden": true
+        },
+        "readonly": true
+      },
+      "assignedIGSN": {
+        "options": {
+          "hidden": false
+        },
+        "readonly": true
+      }
+    }
+  }
+}

--- a/aimdl_batch_igsns.json
+++ b/aimdl_batch_igsns.json
@@ -341,76 +341,110 @@
         "uniqueNum": "root.uniqueNumber"
       },
       "readOnly": true,
-      "propertyOrder": 2
+      "propertyOrder": 1
     },
     "projectIdentifier": {
       "title": "Project Identifier",
       "type": "string",
-      "propertyOrder": 3
+      "propertyOrder": 2
     },
     "date": {
       "title": "Date",
       "type": "string",
       "format": "date",
       "description": "Date in YYYY-MM-DD format",
-      "propertyOrder": 4
+      "propertyOrder": 3
     },
     "alloy": {
       "title": "Alloy",
       "type": "string",
-      "propertyOrder": 5
+      "propertyOrder": 4
     },
     "uniqueNumber": {
       "title": "Unique Number",
       "type": "string",
-      "propertyOrder": 6
+      "propertyOrder": 5
     },
     "manufacturer": {
       "title": "Manufacturer",
       "type": "string",
-      "propertyOrder": 7
+      "propertyOrder": 6
     },
     "supplyCompany": {
       "title": "Supply Company",
       "type": "string",
-      "propertyOrder": 8
+      "propertyOrder": 7
     },
     "description": {
       "title": "Description",
       "type": "string",
       "format": "textarea",
-      "propertyOrder": 9
+      "propertyOrder": 8
     },
     "orcidID": {
       "title": "ORCID ID",
       "type": "string",
+      "propertyOrder": 9
+    },
+    "dimensions": {
+      "title": "Sheet Dimensions (mm)",
+      "type": "object",
+      "format": "grid",
+      "properties": {
+        "length": {
+          "title": "Length",
+          "type": "number",
+          "propertyOrder": 0,
+          "options": { "grid_columns": 4 }
+        },
+        "width": {
+          "title": "Width",
+          "type": "number",
+          "propertyOrder": 1,
+          "options": { "grid_columns": 4 }
+        },
+        "thickness": {
+          "title": "Thickness",
+          "type": "number",
+          "propertyOrder": 2,
+          "options": { "grid_columns": 4 }
+        }
+      },
       "propertyOrder": 10
     },
     "machiningParameters": {
       "title": "Machining Parameters",
       "description": "Upload machining parameter file (e.g. EDM Wire or other technique)",
       "$ref": "#/definitions/fileUpload",
-      "propertyOrder": 13
+      "propertyOrder": 11
     },
     "specSheet": {
       "title": "Spec Sheet",
       "description": "Upload the material spec sheet (PDF)",
       "$ref": "#/definitions/fileUpload",
-      "propertyOrder": 14
+      "propertyOrder": 12
+    },
+    "createSampleIGSNs": {
+      "title": "Create Sample IGSNs",
+      "description": "Check to mint IGSNs for the cut samples from this sheet.",
+      "type": "boolean",
+      "format": "checkbox",
+      "default": true,
+      "propertyOrder": 13
     },
     "sampleCount": {
       "title": "Number of Samples",
       "description": "How many samples to cut from this sheet. One IGSN will be minted per sample (suffixed -1, -2, ...).",
       "type": "integer",
       "minimum": 1,
-      "propertyOrder": 15
+      "propertyOrder": 14
     },
     "sampleDescription": {
       "title": "Sample Description",
       "description": "Description applied uniformly to all cut samples from this sheet.",
       "type": "string",
       "format": "textarea",
-      "propertyOrder": 16
+      "propertyOrder": 15
     },
     "sampleDimensions": {
       "title": "Sample Dimensions (mm)",
@@ -422,87 +456,62 @@
           "title": "Length",
           "type": "number",
           "propertyOrder": 0,
-          "options": {
-            "grid_columns": 4
-          }
+          "options": { "grid_columns": 4 }
         },
         "width": {
           "title": "Width",
           "type": "number",
           "propertyOrder": 1,
-          "options": {
-            "grid_columns": 4
-          }
+          "options": { "grid_columns": 4 }
         },
         "thickness": {
           "title": "Thickness",
           "type": "number",
           "propertyOrder": 2,
-          "options": {
-            "grid_columns": 4
-          }
+          "options": { "grid_columns": 4 }
         }
       },
-      "propertyOrder": 17
-    },
-    "dimensions": {
-      "title": "Sheet Dimensions (mm)",
-      "type": "object",
-      "format": "grid",
-      "properties": {
-        "length": {
-          "title": "Length",
-          "type": "number",
-          "propertyOrder": 0,
-          "options": {
-            "grid_columns": 4
-          }
-        },
-        "width": {
-          "title": "Width",
-          "type": "number",
-          "propertyOrder": 1,
-          "options": {
-            "grid_columns": 4
-          }
-        },
-        "thickness": {
-          "title": "Thickness",
-          "type": "number",
-          "propertyOrder": 2,
-          "options": {
-            "grid_columns": 4
-          }
-        }
-      },
-      "propertyOrder": 11
+      "propertyOrder": 16
     }
   },
-  "if": {
-    "properties": {
-      "igsn": {
+  "required": [
+    "projectIdentifier",
+    "date",
+    "alloy",
+    "uniqueNumber",
+    "sampleCount"
+  ],
+  "allOf": [
+    {
+      "if": {
         "properties": {
-          "request": {
-            "const": false
+          "igsn": {
+            "properties": {
+              "request": { "const": false }
+            }
           }
+        }
+      },
+      "then": {
+        "properties": {
+          "igsnMeta": { "options": { "hidden": true }, "readonly": true },
+          "assignedIGSN": { "options": { "hidden": false }, "readonly": true }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "createSampleIGSNs": { "const": false }
+        }
+      },
+      "then": {
+        "properties": {
+          "sampleCount": { "options": { "hidden": true } },
+          "sampleDescription": { "options": { "hidden": true } },
+          "sampleDimensions": { "options": { "hidden": true } }
         }
       }
     }
-  },
-  "then": {
-    "properties": {
-      "igsnMeta": {
-        "options": {
-          "hidden": true
-        },
-        "readonly": true
-      },
-      "assignedIGSN": {
-        "options": {
-          "hidden": false
-        },
-        "readonly": true
-      }
-    }
-  }
+  ]
 }

--- a/aimdl_batch_igsns.json
+++ b/aimdl_batch_igsns.json
@@ -361,24 +361,31 @@
         "hidden": true
       }
     },
+    "_existingSheetLocalId": {
+      "type": "string",
+      "propertyOrder": 0,
+      "template": "{{split existing ' - ' 2}}",
+      "watch": {
+        "existing": "root.existingSheetIGSN"
+      },
+      "options": {
+        "hidden": true
+      }
+    },
     "sheetID": {
       "title": "Sheet ID",
       "description": "Automatically generated local identifier for the sheet",
       "type": "string",
-      "template": "Sheet_{{projId}}_{{replaceAll date '-' ''}}_{{alloy}}_{{uniqueNum}}",
+      "template": "{{#if existingLocalId}}{{existingLocalId}}{{else}}Sheet_{{projId}}_{{replaceAll date '-' ''}}_{{alloy}}_{{uniqueNum}}{{/if}}",
       "watch": {
+        "existingLocalId": "root._existingSheetLocalId",
         "projId": "root.projectIdentifier",
         "date": "root.date",
         "alloy": "root.alloy",
         "uniqueNum": "root.uniqueNumber"
       },
       "readOnly": true,
-      "propertyOrder": 1,
-      "options": {
-        "dependencies": {
-          "sheetIGSNMode": "create"
-        }
-      }
+      "propertyOrder": 1
     },
     "projectIdentifier": {
       "title": "Project Identifier",

--- a/aimdl_batch_igsns.json
+++ b/aimdl_batch_igsns.json
@@ -341,65 +341,80 @@
         "uniqueNum": "root.uniqueNumber"
       },
       "readOnly": true,
-      "propertyOrder": 1
+      "propertyOrder": 2
     },
     "projectIdentifier": {
       "title": "Project Identifier",
       "type": "string",
-      "propertyOrder": 2
+      "propertyOrder": 3
     },
     "date": {
       "title": "Date",
       "type": "string",
       "format": "date",
       "description": "Date in YYYY-MM-DD format",
-      "propertyOrder": 3
+      "propertyOrder": 4
     },
     "alloy": {
       "title": "Alloy",
       "type": "string",
-      "propertyOrder": 4
+      "propertyOrder": 5
     },
     "uniqueNumber": {
       "title": "Unique Number",
       "type": "string",
-      "propertyOrder": 5
+      "propertyOrder": 6
     },
     "manufacturer": {
       "title": "Manufacturer",
       "type": "string",
-      "propertyOrder": 6
+      "propertyOrder": 7
     },
     "supplyCompany": {
       "title": "Supply Company",
       "type": "string",
-      "propertyOrder": 7
+      "propertyOrder": 8
     },
     "description": {
       "title": "Description",
       "type": "string",
       "format": "textarea",
-      "propertyOrder": 8
+      "propertyOrder": 9
     },
     "orcidID": {
       "title": "ORCID ID",
       "type": "string",
-      "propertyOrder": 9
+      "propertyOrder": 10
     },
     "machiningParameters": {
       "title": "Machining Parameters",
       "description": "Upload machining parameter file (e.g. EDM Wire or other technique)",
       "$ref": "#/definitions/fileUpload",
-      "propertyOrder": 11
+      "propertyOrder": 13
     },
     "specSheet": {
       "title": "Spec Sheet",
       "description": "Upload the material spec sheet (PDF)",
       "$ref": "#/definitions/fileUpload",
-      "propertyOrder": 12
+      "propertyOrder": 14
     },
-    "dimensions": {
-      "title": "Dimensions (mm)",
+    "sampleCount": {
+      "title": "Number of Samples",
+      "description": "How many samples to cut from this sheet. One IGSN will be minted per sample (suffixed -1, -2, ...).",
+      "type": "integer",
+      "minimum": 1,
+      "propertyOrder": 15
+    },
+    "sampleDescription": {
+      "title": "Sample Description",
+      "description": "Description applied uniformly to all cut samples from this sheet.",
+      "type": "string",
+      "format": "textarea",
+      "propertyOrder": 16
+    },
+    "sampleDimensions": {
+      "title": "Sample Dimensions (mm)",
+      "description": "Dimensions of individual cut samples (may differ from sheet dimensions).",
       "type": "object",
       "format": "grid",
       "properties": {
@@ -428,7 +443,39 @@
           }
         }
       },
-      "propertyOrder": 10
+      "propertyOrder": 17
+    },
+    "dimensions": {
+      "title": "Sheet Dimensions (mm)",
+      "type": "object",
+      "format": "grid",
+      "properties": {
+        "length": {
+          "title": "Length",
+          "type": "number",
+          "propertyOrder": 0,
+          "options": {
+            "grid_columns": 4
+          }
+        },
+        "width": {
+          "title": "Width",
+          "type": "number",
+          "propertyOrder": 1,
+          "options": {
+            "grid_columns": 4
+          }
+        },
+        "thickness": {
+          "title": "Thickness",
+          "type": "number",
+          "propertyOrder": 2,
+          "options": {
+            "grid_columns": 4
+          }
+        }
+      },
+      "propertyOrder": 11
     }
   },
   "if": {

--- a/aimdl_batch_igsns.json
+++ b/aimdl_batch_igsns.json
@@ -314,7 +314,7 @@
     },
     "existingSheetIGSN": {
       "title": "Sheet IGSN",
-      "description": "Search for an existing sheet IGSN",
+      "description": "Search for an existing sheet IGSN. Only IGSNs with a local identifier following the Sheet_ naming convention will appear.",
       "type": "string",
       "format": "autocomplete",
       "propertyOrder": -1,

--- a/aimdl_batch_igsns.json
+++ b/aimdl_batch_igsns.json
@@ -164,6 +164,56 @@
         }
       }
     },
+    "fileUpload": {
+      "title": "File",
+      "type": "object",
+      "format": "grid",
+      "properties": {
+        "file": {
+          "title": "Uploaded File ID",
+          "type": "string",
+          "propertyOrder": 1,
+          "links": [
+            {
+              "rel": "View",
+              "title": "View",
+              "href": "/api/v1/file/{{self}}/download?contentDisposition=inline",
+              "class": "girder-file-link"
+            },
+            {
+              "rel": "Download",
+              "title": "Download",
+              "href": "/api/v1/file/{{self}}/download",
+              "download": true,
+              "class": "girder-file-link"
+            }
+          ]
+        },
+        "button": {
+          "title": "Click to Upload",
+          "format": "button",
+          "options": {
+            "button": {
+              "action": "button1CB",
+              "uploadFor": "file"
+            }
+          },
+          "propertyOrder": 2
+        },
+        "targetPath": {
+          "type": "string",
+          "title": "Target Path",
+          "watch": {
+            "path": "root.sheetID"
+          },
+          "template": "{{path}}",
+          "options": {
+            "hidden": true
+          },
+          "propertyOrder": 3
+        }
+      }
+    },
     "igsn": {
       "id": "igsn",
       "type": "object",
@@ -335,6 +385,18 @@
       "title": "ORCID ID",
       "type": "string",
       "propertyOrder": 9
+    },
+    "machiningParameters": {
+      "title": "Machining Parameters",
+      "description": "Upload machining parameter file (e.g. EDM Wire or other technique)",
+      "$ref": "#/definitions/fileUpload",
+      "propertyOrder": 11
+    },
+    "specSheet": {
+      "title": "Spec Sheet",
+      "description": "Upload the material spec sheet (PDF)",
+      "$ref": "#/definitions/fileUpload",
+      "propertyOrder": 12
     },
     "dimensions": {
       "title": "Dimensions (mm)",

--- a/aimdl_batch_igsns.json
+++ b/aimdl_batch_igsns.json
@@ -302,12 +302,15 @@
     }
   },
   "properties": {
-    "useExistingIGSN": {
-      "title": "Use Existing Sheet IGSN",
-      "type": "boolean",
-      "format": "checkbox",
-      "default": false,
-      "propertyOrder": -2
+    "sheetIGSNMode": {
+      "title": "Sheet IGSN",
+      "type": "string",
+      "enum": ["create", "existing"],
+      "default": "create",
+      "propertyOrder": -2,
+      "options": {
+        "enum_titles": ["Create new IGSN", "Use existing IGSN"]
+      }
     },
     "existingSheetIGSN": {
       "title": "Sheet IGSN",
@@ -324,7 +327,7 @@
           "debounceTime": 500
         },
         "dependencies": {
-          "useExistingIGSN": true
+          "sheetIGSNMode": "existing"
         }
       }
     },
@@ -347,7 +350,7 @@
       "options": {
         "hidden": false,
         "dependencies": {
-          "useExistingIGSN": false
+          "sheetIGSNMode": "create"
         }
       }
     },
@@ -373,7 +376,7 @@
       "propertyOrder": 1,
       "options": {
         "dependencies": {
-          "useExistingIGSN": false
+          "sheetIGSNMode": "create"
         }
       }
     },
@@ -383,7 +386,7 @@
       "propertyOrder": 2,
       "options": {
         "dependencies": {
-          "useExistingIGSN": false
+          "sheetIGSNMode": "create"
         }
       }
     },
@@ -395,7 +398,7 @@
       "propertyOrder": 3,
       "options": {
         "dependencies": {
-          "useExistingIGSN": false
+          "sheetIGSNMode": "create"
         }
       }
     },
@@ -405,7 +408,7 @@
       "propertyOrder": 4,
       "options": {
         "dependencies": {
-          "useExistingIGSN": false
+          "sheetIGSNMode": "create"
         }
       }
     },
@@ -415,7 +418,7 @@
       "propertyOrder": 5,
       "options": {
         "dependencies": {
-          "useExistingIGSN": false
+          "sheetIGSNMode": "create"
         }
       }
     },
@@ -425,7 +428,7 @@
       "propertyOrder": 6,
       "options": {
         "dependencies": {
-          "useExistingIGSN": false
+          "sheetIGSNMode": "create"
         }
       }
     },
@@ -435,7 +438,7 @@
       "propertyOrder": 7,
       "options": {
         "dependencies": {
-          "useExistingIGSN": false
+          "sheetIGSNMode": "create"
         }
       }
     },
@@ -446,7 +449,7 @@
       "propertyOrder": 8,
       "options": {
         "dependencies": {
-          "useExistingIGSN": false
+          "sheetIGSNMode": "create"
         }
       }
     },
@@ -456,7 +459,7 @@
       "propertyOrder": 9,
       "options": {
         "dependencies": {
-          "useExistingIGSN": false
+          "sheetIGSNMode": "create"
         }
       }
     },
@@ -490,7 +493,7 @@
       "propertyOrder": 10,
       "options": {
         "dependencies": {
-          "useExistingIGSN": false
+          "sheetIGSNMode": "create"
         }
       }
     },
@@ -501,7 +504,7 @@
       "propertyOrder": 11,
       "options": {
         "dependencies": {
-          "useExistingIGSN": false
+          "sheetIGSNMode": "create"
         }
       }
     },
@@ -512,7 +515,7 @@
       "propertyOrder": 12,
       "options": {
         "dependencies": {
-          "useExistingIGSN": false
+          "sheetIGSNMode": "create"
         }
       }
     },

--- a/aimdl_batch_igsns.json
+++ b/aimdl_batch_igsns.json
@@ -28,9 +28,9 @@
           "type": "string",
           "description": "Originating Institution",
           "enum": [
-            "JHU"
+            "JH"
           ],
-          "default": "JHU",
+          "default": "JH",
           "propertyOrder": 1,
           "options": {
             "titleHidden": true,
@@ -305,11 +305,17 @@
     "sheetIGSNMode": {
       "title": "Sheet IGSN",
       "type": "string",
-      "enum": ["create", "existing"],
+      "enum": [
+        "create",
+        "existing"
+      ],
       "default": "create",
       "propertyOrder": -2,
       "options": {
-        "enum_titles": ["Create new IGSN", "Use existing IGSN"]
+        "enum_titles": [
+          "Create new IGSN",
+          "Use existing IGSN"
+        ]
       }
     },
     "existingSheetIGSN": {
@@ -480,21 +486,27 @@
           "type": "number",
           "exclusiveMinimum": 0,
           "propertyOrder": 0,
-          "options": { "grid_columns": 4 }
+          "options": {
+            "grid_columns": 4
+          }
         },
         "width": {
           "title": "Width",
           "type": "number",
           "exclusiveMinimum": 0,
           "propertyOrder": 1,
-          "options": { "grid_columns": 4 }
+          "options": {
+            "grid_columns": 4
+          }
         },
         "thickness": {
           "title": "Thickness",
           "type": "number",
           "exclusiveMinimum": 0,
           "propertyOrder": 2,
-          "options": { "grid_columns": 4 }
+          "options": {
+            "grid_columns": 4
+          }
         }
       },
       "propertyOrder": 10,
@@ -580,21 +592,27 @@
           "type": "number",
           "exclusiveMinimum": 0,
           "propertyOrder": 0,
-          "options": { "grid_columns": 4 }
+          "options": {
+            "grid_columns": 4
+          }
         },
         "width": {
           "title": "Width",
           "type": "number",
           "exclusiveMinimum": 0,
           "propertyOrder": 1,
-          "options": { "grid_columns": 4 }
+          "options": {
+            "grid_columns": 4
+          }
         },
         "thickness": {
           "title": "Thickness",
           "type": "number",
           "exclusiveMinimum": 0,
           "propertyOrder": 2,
-          "options": { "grid_columns": 4 }
+          "options": {
+            "grid_columns": 4
+          }
         }
       },
       "propertyOrder": 17,
@@ -608,10 +626,19 @@
   "allOf": [
     {
       "if": {
-        "properties": { "sheetIGSNMode": { "const": "create" } }
+        "properties": {
+          "sheetIGSNMode": {
+            "const": "create"
+          }
+        }
       },
       "then": {
-        "required": ["projectIdentifier", "date", "alloy", "uniqueNumber"]
+        "required": [
+          "projectIdentifier",
+          "date",
+          "alloy",
+          "uniqueNumber"
+        ]
       }
     },
     {
@@ -619,15 +646,27 @@
         "properties": {
           "igsn": {
             "properties": {
-              "request": { "const": false }
+              "request": {
+                "const": false
+              }
             }
           }
         }
       },
       "then": {
         "properties": {
-          "igsnMeta": { "options": { "hidden": true }, "readonly": true },
-          "assignedIGSN": { "options": { "hidden": false }, "readonly": true }
+          "igsnMeta": {
+            "options": {
+              "hidden": true
+            },
+            "readonly": true
+          },
+          "assignedIGSN": {
+            "options": {
+              "hidden": false
+            },
+            "readonly": true
+          }
         }
       }
     }

--- a/aimdl_batch_igsns.json
+++ b/aimdl_batch_igsns.json
@@ -549,6 +549,7 @@
       "title": "Number of Samples",
       "description": "How many samples to cut from this sheet. One IGSN will be minted per sample (suffixed -1, -2, ...).",
       "type": "integer",
+      "minimum": 1,
       "propertyOrder": 15,
       "options": {
         "dependencies": {

--- a/aimdl_batch_igsns.json
+++ b/aimdl_batch_igsns.json
@@ -593,25 +593,31 @@
       }
     }
   },
-  "required": [
-    "projectIdentifier",
-    "date",
-    "alloy",
-    "uniqueNumber"
-  ],
-  "if": {
-    "properties": {
-      "igsn": {
+  "allOf": [
+    {
+      "if": {
+        "properties": { "sheetIGSNMode": { "const": "create" } }
+      },
+      "then": {
+        "required": ["projectIdentifier", "date", "alloy", "uniqueNumber"]
+      }
+    },
+    {
+      "if": {
         "properties": {
-          "request": { "const": false }
+          "igsn": {
+            "properties": {
+              "request": { "const": false }
+            }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "igsnMeta": { "options": { "hidden": true }, "readonly": true },
+          "assignedIGSN": { "options": { "hidden": false }, "readonly": true }
         }
       }
     }
-  },
-  "then": {
-    "properties": {
-      "igsnMeta": { "options": { "hidden": true }, "readonly": true },
-      "assignedIGSN": { "options": { "hidden": false }, "readonly": true }
-    }
-  }
+  ]
 }

--- a/aimdl_batch_igsns.json
+++ b/aimdl_batch_igsns.json
@@ -117,6 +117,10 @@
         "title": {
           "type": "string",
           "title": "Sample Name",
+          "template": "{{sheetId}}",
+          "watch": {
+            "sheetId": "root.sheetID"
+          },
           "readOnly": true,
           "propertyOrder": 5,
           "options": {
@@ -274,6 +278,95 @@
       "options": {
         "hidden": true
       }
+    },
+    "sheetID": {
+      "title": "Sheet ID",
+      "description": "Automatically generated local identifier for the sheet",
+      "type": "string",
+      "template": "Sheet_{{projId}}_{{replaceAll date '-' ''}}_{{alloy}}_{{uniqueNum}}",
+      "watch": {
+        "projId": "root.projectIdentifier",
+        "date": "root.date",
+        "alloy": "root.alloy",
+        "uniqueNum": "root.uniqueNumber"
+      },
+      "readOnly": true,
+      "propertyOrder": 1
+    },
+    "projectIdentifier": {
+      "title": "Project Identifier",
+      "type": "string",
+      "propertyOrder": 2
+    },
+    "date": {
+      "title": "Date",
+      "type": "string",
+      "format": "date",
+      "description": "Date in YYYY-MM-DD format",
+      "propertyOrder": 3
+    },
+    "alloy": {
+      "title": "Alloy",
+      "type": "string",
+      "propertyOrder": 4
+    },
+    "uniqueNumber": {
+      "title": "Unique Number",
+      "type": "string",
+      "propertyOrder": 5
+    },
+    "manufacturer": {
+      "title": "Manufacturer",
+      "type": "string",
+      "propertyOrder": 6
+    },
+    "supplyCompany": {
+      "title": "Supply Company",
+      "type": "string",
+      "propertyOrder": 7
+    },
+    "description": {
+      "title": "Description",
+      "type": "string",
+      "format": "textarea",
+      "propertyOrder": 8
+    },
+    "orcidID": {
+      "title": "ORCID ID",
+      "type": "string",
+      "propertyOrder": 9
+    },
+    "dimensions": {
+      "title": "Dimensions (mm)",
+      "type": "object",
+      "format": "grid",
+      "properties": {
+        "length": {
+          "title": "Length",
+          "type": "number",
+          "propertyOrder": 0,
+          "options": {
+            "grid_columns": 4
+          }
+        },
+        "width": {
+          "title": "Width",
+          "type": "number",
+          "propertyOrder": 1,
+          "options": {
+            "grid_columns": 4
+          }
+        },
+        "thickness": {
+          "title": "Thickness",
+          "type": "number",
+          "propertyOrder": 2,
+          "options": {
+            "grid_columns": 4
+          }
+        }
+      },
+      "propertyOrder": 10
     }
   },
   "if": {

--- a/aimdl_batch_igsns.json
+++ b/aimdl_batch_igsns.json
@@ -394,18 +394,21 @@
         "length": {
           "title": "Length",
           "type": "number",
+          "exclusiveMinimum": 0,
           "propertyOrder": 0,
           "options": { "grid_columns": 4 }
         },
         "width": {
           "title": "Width",
           "type": "number",
+          "exclusiveMinimum": 0,
           "propertyOrder": 1,
           "options": { "grid_columns": 4 }
         },
         "thickness": {
           "title": "Thickness",
           "type": "number",
+          "exclusiveMinimum": 0,
           "propertyOrder": 2,
           "options": { "grid_columns": 4 }
         }
@@ -464,18 +467,21 @@
         "length": {
           "title": "Length",
           "type": "number",
+          "exclusiveMinimum": 0,
           "propertyOrder": 0,
           "options": { "grid_columns": 4 }
         },
         "width": {
           "title": "Width",
           "type": "number",
+          "exclusiveMinimum": 0,
           "propertyOrder": 1,
           "options": { "grid_columns": 4 }
         },
         "thickness": {
           "title": "Thickness",
           "type": "number",
+          "exclusiveMinimum": 0,
           "propertyOrder": 2,
           "options": { "grid_columns": 4 }
         }

--- a/aimdl_batch_igsns.json
+++ b/aimdl_batch_igsns.json
@@ -302,6 +302,32 @@
     }
   },
   "properties": {
+    "useExistingIGSN": {
+      "title": "Use Existing Sheet IGSN",
+      "type": "boolean",
+      "format": "checkbox",
+      "default": false,
+      "propertyOrder": -2
+    },
+    "existingSheetIGSN": {
+      "title": "Sheet IGSN",
+      "description": "Search for an existing sheet IGSN",
+      "type": "string",
+      "format": "autocomplete",
+      "propertyOrder": -1,
+      "options": {
+        "autocomplete": {
+          "search": "search_deposition",
+          "renderResult": "render_deposition",
+          "getResultValue": "get_deposition_value",
+          "autoSelect": true,
+          "debounceTime": 500
+        },
+        "dependencies": {
+          "useExistingIGSN": true
+        }
+      }
+    },
     "assignedIGSN": {
       "type": "string",
       "propertyOrder": 0,
@@ -319,7 +345,10 @@
       "$ref": "#/definitions/igsnMetadata",
       "propertyOrder": 0,
       "options": {
-        "hidden": false
+        "hidden": false,
+        "dependencies": {
+          "useExistingIGSN": false
+        }
       }
     },
     "igsn": {
@@ -341,50 +370,95 @@
         "uniqueNum": "root.uniqueNumber"
       },
       "readOnly": true,
-      "propertyOrder": 1
+      "propertyOrder": 1,
+      "options": {
+        "dependencies": {
+          "useExistingIGSN": false
+        }
+      }
     },
     "projectIdentifier": {
       "title": "Project Identifier",
       "type": "string",
-      "propertyOrder": 2
+      "propertyOrder": 2,
+      "options": {
+        "dependencies": {
+          "useExistingIGSN": false
+        }
+      }
     },
     "date": {
       "title": "Date",
       "type": "string",
       "format": "date",
       "description": "Date in YYYY-MM-DD format",
-      "propertyOrder": 3
+      "propertyOrder": 3,
+      "options": {
+        "dependencies": {
+          "useExistingIGSN": false
+        }
+      }
     },
     "alloy": {
       "title": "Alloy",
       "type": "string",
-      "propertyOrder": 4
+      "propertyOrder": 4,
+      "options": {
+        "dependencies": {
+          "useExistingIGSN": false
+        }
+      }
     },
     "uniqueNumber": {
       "title": "Unique Number",
       "type": "string",
-      "propertyOrder": 5
+      "propertyOrder": 5,
+      "options": {
+        "dependencies": {
+          "useExistingIGSN": false
+        }
+      }
     },
     "manufacturer": {
       "title": "Manufacturer",
       "type": "string",
-      "propertyOrder": 6
+      "propertyOrder": 6,
+      "options": {
+        "dependencies": {
+          "useExistingIGSN": false
+        }
+      }
     },
     "supplyCompany": {
       "title": "Supply Company",
       "type": "string",
-      "propertyOrder": 7
+      "propertyOrder": 7,
+      "options": {
+        "dependencies": {
+          "useExistingIGSN": false
+        }
+      }
     },
     "description": {
       "title": "Description",
       "type": "string",
       "format": "textarea",
-      "propertyOrder": 8
+      "propertyOrder": 8,
+      "options": {
+        "dependencies": {
+          "useExistingIGSN": false
+        }
+      }
     },
     "orcidID": {
       "title": "ORCID ID",
       "type": "string",
-      "propertyOrder": 9
+      "propertyOrder": 9,
+      "options": {
+        "dependencies": {
+          "useExistingIGSN": false
+        }
+      }
     },
     "dimensions": {
       "title": "Sheet Dimensions (mm)",
@@ -413,19 +487,34 @@
           "options": { "grid_columns": 4 }
         }
       },
-      "propertyOrder": 10
+      "propertyOrder": 10,
+      "options": {
+        "dependencies": {
+          "useExistingIGSN": false
+        }
+      }
     },
     "machiningParameters": {
       "title": "Machining Parameters",
       "description": "Upload machining parameter file (e.g. EDM Wire or other technique)",
       "$ref": "#/definitions/fileUpload",
-      "propertyOrder": 11
+      "propertyOrder": 11,
+      "options": {
+        "dependencies": {
+          "useExistingIGSN": false
+        }
+      }
     },
     "specSheet": {
       "title": "Spec Sheet",
       "description": "Upload the material spec sheet (PDF)",
       "$ref": "#/definitions/fileUpload",
-      "propertyOrder": 12
+      "propertyOrder": 12,
+      "options": {
+        "dependencies": {
+          "useExistingIGSN": false
+        }
+      }
     },
     "createSampleIGSNs": {
       "title": "Create Sample IGSNs",


### PR DESCRIPTION
## Summary
- Adds `aimdl_batch_igsns.json`, a two-part form for registering sheet and batch sample IGSNs for AIMD-L at JHU, and `aimdl_batch_igsns.js` for basic functions like date reformatting

## Current Issues

Saving a form gives 'Prefix must be 6 characters long', which I assume has to do with the backend code @Xarthisius. I'm happy to look into that and code it so you can save time and I can get more familiar with how igsn creation works

## Discussion

Users can make a sheet without making samples. however, they can’t make samples without a sheet. there is a scenario where samples come pre-cut, so I assumed we should still create a igsn for the sheet they should (but may not) originate from. 

## Questions 

- orchid id field: should i put it under igsnMetadata for the request?
- batch method field: had value ‘imqcam’ (as found in the printer build form). I put value 'aimdl' 
- find a way to assign igsn.alternateIdentifier using sheetId
- match the igsn suffix with the alternate identifier suffix for cut samples

## Test plan
- [x] Verify sheet IGSN fields (institution, group, material, submaterial) render and prefill correctly
- [x] Verify `sheetID` auto-computes from projectIdentifier, date, alloy, uniqueNumber
- [x] Verify file upload works for machiningParameters and specSheet
- [x] Verify "Create Sample IGSNs" checkbox shows/hides sampleCount, sampleDescription, sampleDimensions
- [x] Verify zero-valued dimensions are not accepted
- [ ] Verify required fields (projectIdentifier, date, alloy, uniqueNumber) are enforced
- [ ] Verify form entries, IGSNs and sub-IGSNs are created correctly