### PR TITLE
Allow null values for material thickness field

### DIFF
--- a/material_properties.json
+++ b/material_properties.json
@@ -28,9 +28,10 @@
       "propertyOrder": 1
     },
     "materialThickness": {
-      "type": "number",
+      "type": ["number", "null"],
       "title": "Material Thickness",
       "description": "in mm",
+      "default": null,
       "propertyOrder": 2
     },
     "measurements": {


### PR DESCRIPTION
Updates the materialThickness field schema to accept null values, matching the pattern used for measurement fields. This allows entries without thickness data to be submitted without validation errors.